### PR TITLE
docs(specs): add OpenAPI YAML specs and markdown specifications

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -1,0 +1,5 @@
+extends:
+  - recommended
+
+rules:
+  no-server-example.com: off

--- a/COMMERCIAL-LICENSE.txt
+++ b/COMMERCIAL-LICENSE.txt
@@ -1,0 +1,72 @@
+COMMERCIAL LICENSE — Waterfall
+
+Version dated 2025-06-11
+
+1. Purpose of the License
+
+This commercial license grants the client organization (the "Client") a non-exclusive, non-transferable right to use the software Waterfall for professional purposes, under the terms defined below.
+
+2. Scope of the License
+
+This license allows the Client to:
+
+    Run the software in its internal environment (on-premise or private cloud)
+
+    Use the software in a commercial context, without any obligation to redistribute the source code
+
+    Access professional features and proprietary modules
+
+    Benefit from technical support, updates, and software improvements
+
+The license covers a specific number of users or instances, as specified in the commercial appendix or invoice.
+
+3. Duration and Renewal
+
+The license is valid for a period of 12 months from the subscription date, and is automatically renewable unless terminated in writing 30 days before expiration.
+
+4. Restrictions
+
+The Client agrees not to:
+
+    Resell, transfer, or redistribute the software to third parties
+
+    Integrate the software into a commercial SaaS offering without explicit agreement
+
+    Bypass or circumvent security or licensing mechanisms
+
+    Access or modify proprietary modules without authorization
+
+5. Intellectual Property
+
+The software, including proprietary components, remains the exclusive property of [Your name or company].
+The Client acquires no intellectual property rights other than those explicitly listed.
+
+6. Support and Services
+
+The Client benefits from the level of support described in their commercial contract:
+
+    Support by email or dedicated platform
+
+    Guaranteed response time according to the chosen offer
+
+    Access to bug fixes, improvements, and new versions during the license period
+
+7. Liability
+
+The software is provided "as is". In no event shall [Your name] be liable for indirect damages, business interruption, or data loss.
+
+Maximum liability is limited to the total amount paid by the Client in the last 12 months.
+
+8. Termination
+
+The license may be terminated in case of non-compliance with the conditions. In case of termination, the Client agrees to immediately cease all use of the software.
+
+9. Governing Law
+
+This contract is governed by French law. In case of dispute, the parties agree to seek an amicable resolution before any legal proceedings.
+
+10. Contact
+
+For any commercial or technical request:
+📧 contact@waterfall-project.pro
+🌐 https://waterfall-project.pro

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,67 @@
+<div align="center">
+  <img src="docs/assets/waterfall_logo.svg" alt="Waterfall Logo" width="200"/>
+</div>
+
+# Project License: Dual AGPLv3 / Commercial License
+
+This project is distributed under a **dual license**:
+
+## 🟢 1. Community Version – AGPLv3
+
+The source code of this project is available under the **GNU Affero General Public License v3.0 (AGPLv3)**.
+
+### 👉 Main Rights:
+
+- You can **use**, **modify**, and **redistribute** the code freely.
+- You can **host** the application yourself, including in a SaaS environment, provided you publish any modifications to the source code.
+
+### ⚠️ Conditions:
+
+- Any **modification** or **distribution**, including as a web service, must be published under the same license (AGPLv3).
+- You **may not** use this code in a closed or commercial product **without complying with the terms of the AGPLv3**.
+
+> 🔗 Full text: [https://www.gnu.org/licenses/agpl-3.0.html](https://www.gnu.org/licenses/agpl-3.0.html)
+
+---
+
+## 🔒 2. Commercial Version – Proprietary License
+
+For companies and organizations seeking:
+
+- **Use without AGPL constraints**
+- **Advanced features**
+- **Integration into proprietary systems**
+- **Professional support**
+- **SaaS hosting** without the obligation to redistribute the code
+
+…a **commercial license** is available.
+
+### 🎯 Advantages of the Commercial License:
+
+- Use of the software in a professional or closed environment
+- Access to **proprietary modules** (advanced authentication, multi-project dashboards, etc.)
+- **Priority support** and guaranteed updates
+- Option for **managed hosting** or **on-premise**
+- **Service Level Agreement (SLA)** contract
+
+📩 For any commercial license request, please contact:  
+**contact@waterfall-project.pro**
+
+---
+
+## 📘 Summary
+
+| Usage                                         | Required License      |
+|-----------------------------------------------|----------------------|
+| Personal or academic use, open source         | AGPLv3               |
+| Internal company use, self-hosted             | AGPLv3 or commercial |
+| SaaS without code redistribution              | Commercial license   |
+| Integration into a proprietary product        | Commercial license   |
+| Access to support and premium features        | Commercial license   |
+
+---
+
+## 🙏 Acknowledgements
+
+We believe that a project management tool can be both **free**, **open**, **useful for engineers**, and **professionally viable**.  
+Thank you for supporting this project and its mission.

--- a/openapi/dummies-api.yaml
+++ b/openapi/dummies-api.yaml
@@ -9,8 +9,8 @@ info:
   contact:
     name: Backend Team
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: AGPL-3.0-only / Commercial
+    url: https://www.gnu.org/licenses/agpl-3.0.html
 
 servers:
   - url: http://localhost:5000

--- a/openapi/dummies-api.yaml
+++ b/openapi/dummies-api.yaml
@@ -1,0 +1,743 @@
+openapi: 3.0.3
+info:
+  title: Dummies CRUD API
+  description: |
+    Complete CRUD API for the "Dummy" resource, serving as a reference implementation 
+    in wfp-flask-template. Demonstrates JWT authentication, Guardian authorization, 
+    multi-tenancy isolation, pagination, validation, and error handling patterns.
+  version: 1.0.0
+  contact:
+    name: Backend Team
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  - url: http://localhost:5000
+    description: Development server
+  - url: https://api-staging.waterfall.com
+    description: Staging server
+  - url: https://api.waterfall.com
+    description: Production server
+
+tags:
+  - name: Dummies
+    description: CRUD operations for Dummy resources
+
+security:
+  - CookieAuth: []
+
+paths:
+  /v0/dummies:
+    get:
+      tags:
+        - Dummies
+      summary: List dummies
+      description: |
+        Retrieve a paginated list of dummies for the authenticated user's company 
+        with optional sorting. Automatically filters by company_id from JWT token.
+        Requires Guardian LIST permission.
+      operationId: listDummies
+      x-guardian-operation: LIST
+      security:
+        - CookieAuth: []
+      parameters:
+        - name: page
+          in: query
+          description: Page number (1-indexed)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: per_page
+          in: query
+          description: Items per page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: sort_by
+          in: query
+          description: Field to sort by
+          required: false
+          schema:
+            type: string
+            enum: [name, created_at, updated_at]
+            default: created_at
+        - name: sort_order
+          in: query
+          description: Sort direction
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - name: X-Correlation-ID
+          in: header
+          description: Request correlation ID for distributed tracing (auto-generated if not provided)
+          required: false
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Dummies retrieved successfully (may be empty)
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DummyListResponse'
+              examples:
+                with_data:
+                  summary: Page with 2 dummies
+                  value:
+                    data:
+                      - id: "123e4567-e89b-12d3-a456-426614174000"
+                        name: "Example Dummy"
+                        description: "This is an example dummy resource"
+                        company_id: "987e6543-e21b-12d3-a456-426614174000"
+                        is_active: true
+                        created_at: "2026-01-07T10:00:00Z"
+                        updated_at: "2026-01-07T10:00:00Z"
+                      - id: "223e4567-e89b-12d3-a456-426614174001"
+                        name: "Another Dummy"
+                        description: null
+                        company_id: "987e6543-e21b-12d3-a456-426614174000"
+                        is_active: true
+                        created_at: "2026-01-07T09:30:00Z"
+                        updated_at: "2026-01-07T09:30:00Z"
+                    page: 1
+                    per_page: 20
+                    total: 42
+                    total_pages: 3
+                empty:
+                  summary: Empty result set
+                  value:
+                    data: []
+                    page: 1
+                    per_page: 20
+                    total: 0
+                    total_pages: 0
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          description: Invalid query parameters
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              example:
+                message: "Validation failed"
+                errors:
+                  per_page: ["Must be less than or equal to 100"]
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+          
+    post:
+      tags:
+        - Dummies
+      summary: Create dummy
+      description: |
+        Create a new dummy resource for the authenticated user's company. 
+        Name must be unique within the company. Requires Guardian CREATE permission.
+      operationId: createDummy
+      x-guardian-operation: CREATE
+      security:
+        - CookieAuth: []
+      parameters:
+        - name: X-Correlation-ID
+          in: header
+          description: Request correlation ID for distributed tracing
+          required: false
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DummyCreateRequest'
+            examples:
+              with_description:
+                summary: Create with description
+                value:
+                  name: "My New Dummy"
+                  description: "This is a test dummy resource"
+              minimal:
+                summary: Create without description
+                value:
+                  name: "Minimal Dummy"
+      responses:
+        '201':
+          description: Dummy created successfully
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DummyResponse'
+              example:
+                data:
+                  id: "323e4567-e89b-12d3-a456-426614174002"
+                  name: "My New Dummy"
+                  description: "This is a test dummy resource"
+                  company_id: "987e6543-e21b-12d3-a456-426614174000"
+                  is_active: true
+                  created_at: "2026-01-07T11:00:00Z"
+                  updated_at: "2026-01-07T11:00:00Z"
+                message: "Dummy created successfully"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Dummy name already exists in company
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Dummy with this name already exists in your company"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+        '422':
+          description: Validation errors
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              example:
+                message: "Validation failed"
+                errors:
+                  name: ["Field is required"]
+                  description: ["Length must be between 0 and 1000"]
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v0/dummies/{id}:
+    parameters:
+      - name: id
+        in: path
+        description: Dummy unique identifier (UUID)
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: X-Correlation-ID
+        in: header
+        description: Request correlation ID for distributed tracing
+        required: false
+        schema:
+          type: string
+          format: uuid
+          
+    get:
+      tags:
+        - Dummies
+      summary: Retrieve dummy
+      description: |
+        Retrieve a single dummy by ID. Must belong to authenticated user's company.
+        Requires Guardian READ permission.
+      operationId: getDummy
+      x-guardian-operation: READ
+      security:
+        - CookieAuth: []
+      responses:
+        '200':
+          description: Dummy retrieved successfully
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DummyResponse'
+              example:
+                data:
+                  id: "123e4567-e89b-12d3-a456-426614174000"
+                  name: "Example Dummy"
+                  description: "This is an example dummy resource"
+                  company_id: "987e6543-e21b-12d3-a456-426614174000"
+                  is_active: true
+                  created_at: "2026-01-07T10:00:00Z"
+                  updated_at: "2026-01-07T10:00:00Z"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+          
+    patch:
+      tags:
+        - Dummies
+      summary: Update dummy
+      description: |
+        Partially update a dummy. Only provided fields are updated. 
+        Must belong to authenticated user's company. 
+        Requires Guardian UPDATE permission.
+      operationId: updateDummy
+      x-guardian-operation: UPDATE
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DummyUpdateRequest'
+            examples:
+              update_name:
+                summary: Update only name
+                value:
+                  name: "Updated Dummy Name"
+              update_multiple:
+                summary: Update multiple fields
+                value:
+                  name: "Completely Updated"
+                  description: "New description here"
+                  is_active: false
+      responses:
+        '200':
+          description: Dummy updated successfully
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DummyResponse'
+              example:
+                data:
+                  id: "123e4567-e89b-12d3-a456-426614174000"
+                  name: "Updated Dummy Name"
+                  description: "This is an example dummy resource"
+                  company_id: "987e6543-e21b-12d3-a456-426614174000"
+                  is_active: true
+                  created_at: "2026-01-07T10:00:00Z"
+                  updated_at: "2026-01-07T11:30:00Z"
+                message: "Dummy updated successfully"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Updated name conflicts with existing dummy
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Dummy with this name already exists in your company"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+        '422':
+          description: Validation errors
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              example:
+                message: "Validation failed"
+                errors:
+                  name: ["Length must be between 3 and 255"]
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+          
+    delete:
+      tags:
+        - Dummies
+      summary: Delete dummy
+      description: |
+        Soft delete a dummy (sets is_active=false). Must belong to authenticated 
+        user's company. Requires Guardian DELETE permission.
+      operationId: deleteDummy
+      x-guardian-operation: DELETE
+      security:
+        - CookieAuth: []
+      responses:
+        '204':
+          description: Dummy deleted successfully (soft delete)
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content: {}
+        '410':
+          description: Dummy already deleted
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/X-Correlation-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Dummy already deleted"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  securitySchemes:
+    CookieAuth:
+      type: apiKey
+      in: cookie
+      name: access_token
+      description: |
+        JWT token stored in HTTP-only cookie. Token must contain claims:
+        - user_id (UUID)
+        - company_id (UUID)
+        - email (string)
+
+  headers:
+    X-Correlation-ID:
+      description: Request correlation ID for distributed tracing
+      schema:
+        type: string
+        format: uuid
+    X-RateLimit-Limit:
+      description: Maximum requests per window
+      schema:
+        type: integer
+        example: 100
+    X-RateLimit-Remaining:
+      description: Remaining requests in current window
+      schema:
+        type: integer
+        example: 95
+    X-RateLimit-Reset:
+      description: Unix timestamp when limit resets
+      schema:
+        type: integer
+        format: int64
+        example: 1704628800
+
+  schemas:
+    Dummy:
+      type: object
+      required:
+        - id
+        - name
+        - company_id
+        - is_active
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier
+          readOnly: true
+        name:
+          type: string
+          minLength: 3
+          maxLength: 255
+          description: Dummy name (unique per company)
+        description:
+          type: string
+          maxLength: 1000
+          nullable: true
+          description: Optional description
+        company_id:
+          type: string
+          format: uuid
+          description: Company identifier (from JWT)
+          readOnly: true
+        is_active:
+          type: boolean
+          description: Active status (false if soft-deleted)
+          default: true
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp (UTC)
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp (UTC)
+          readOnly: true
+          
+    DummyCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 3
+          maxLength: 255
+          description: Unique name for the dummy within the company
+        description:
+          type: string
+          maxLength: 1000
+          nullable: true
+          description: Optional description
+          
+    DummyUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 3
+          maxLength: 255
+          description: Updated name (must be unique in company)
+        description:
+          type: string
+          maxLength: 1000
+          nullable: true
+          description: Updated description (null to clear)
+        is_active:
+          type: boolean
+          description: Active status. Only false allowed for soft delete; reactivation is not permitted via PATCH.
+          enum: [false]
+          
+    DummyResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/Dummy'
+        message:
+          type: string
+          description: Optional success message
+          
+    DummyListResponse:
+      type: object
+      required:
+        - data
+        - page
+        - per_page
+        - total
+        - total_pages
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Dummy'
+        page:
+          type: integer
+          minimum: 1
+          description: Current page number
+        per_page:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page
+        total:
+          type: integer
+          minimum: 0
+          description: Total number of items
+        total_pages:
+          type: integer
+          minimum: 0
+          description: Total number of pages
+          
+    Error:
+      type: object
+      required:
+        - message
+        - correlation_id
+      properties:
+        message:
+          type: string
+          description: Human-readable error message
+        correlation_id:
+          type: string
+          format: uuid
+          description: Request correlation ID for tracing
+          
+    ValidationError:
+      type: object
+      required:
+        - message
+        - errors
+        - correlation_id
+      properties:
+        message:
+          type: string
+          description: Human-readable error message
+        errors:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          description: Field-specific validation errors
+        correlation_id:
+          type: string
+          format: uuid
+          description: Request correlation ID for tracing
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid JWT token
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/X-Correlation-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: "Missing or invalid JWT token"
+            correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            
+    Forbidden:
+      description: Insufficient Guardian permissions
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/X-Correlation-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            list:
+              summary: List permission denied
+              value:
+                message: "Insufficient permissions to list dummies"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            create:
+              summary: Create permission denied
+              value:
+                message: "Insufficient permissions to create dummies"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            read:
+              summary: Read permission denied
+              value:
+                message: "Insufficient permissions to read this dummy"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            update:
+              summary: Update permission denied
+              value:
+                message: "Insufficient permissions to update this dummy"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            delete:
+              summary: Delete permission denied
+              value:
+                message: "Insufficient permissions to delete this dummy"
+                correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+                
+    NotFound:
+      description: Dummy not found or belongs to another company
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/X-Correlation-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: "Dummy not found"
+            correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            
+    TooManyRequests:
+      description: Rate limit exceeded
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/X-Correlation-ID'
+        X-RateLimit-Limit:
+          $ref: '#/components/headers/X-RateLimit-Limit'
+        X-RateLimit-Remaining:
+          schema:
+            type: integer
+            example: 0
+        X-RateLimit-Reset:
+          $ref: '#/components/headers/X-RateLimit-Reset'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: "Rate limit exceeded. Maximum 100 requests per minute."
+            correlation_id: "550e8400-e29b-41d4-a716-446655440000"
+            
+    InternalServerError:
+      description: Unexpected server error
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/X-Correlation-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: "Internal server error"
+            correlation_id: "550e8400-e29b-41d4-a716-446655440000"

--- a/openapi/health-endpoints.yaml
+++ b/openapi/health-endpoints.yaml
@@ -1,0 +1,420 @@
+openapi: 3.0.3
+info:
+  title: Health, Readiness and Version Endpoints
+  description: |
+    Standardized observability endpoints for Kubernetes health probes, monitoring, 
+    and version tracking. These endpoints are public (no authentication required) and 
+    must be present in all Waterfall microservices.
+  version: 1.0.0
+  contact:
+    name: Backend Team
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+    
+servers:
+  - url: http://localhost:5000
+    description: Development server
+  - url: https://api-staging.waterfall.com
+    description: Staging server
+  - url: https://api.waterfall.com
+    description: Production server
+
+tags:
+  - name: Health
+    description: Service health and readiness checks
+  - name: Version
+    description: Service version information
+
+security: []
+
+paths:
+  /health:
+    get:
+      tags:
+        - Health
+      summary: Liveness probe
+      description: |
+        Checks if the application is alive and functioning. Used by Kubernetes 
+        liveness probes to detect if the container needs restart. Returns 200 OK 
+        even if dependencies are degraded (only fails if app itself is broken).
+      operationId: getHealth
+      responses:
+        '200':
+          description: Service is alive (may be degraded)
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Cache-Control:
+              schema:
+                type: string
+                example: no-cache, no-store, must-revalidate
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/HealthOk'
+                  - $ref: '#/components/schemas/HealthDegraded'
+              examples:
+                healthy:
+                  summary: All systems operational
+                  value:
+                    status: ok
+                    timestamp: "2026-01-07T10:30:00Z"
+                    checks:
+                      database:
+                        status: ok
+                        response_time_ms: 15
+                degraded:
+                  summary: Database issues but service alive
+                  value:
+                    status: degraded
+                    timestamp: "2026-01-07T10:30:00Z"
+                    checks:
+                      database:
+                        status: error
+                        response_time_ms: 3000
+                        error: "Connection timeout"
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Rate limit exceeded"
+                timestamp: "2026-01-07T10:30:00Z"
+        '500':
+          description: Application itself is broken
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthError'
+              example:
+                status: error
+                timestamp: "2026-01-07T10:30:00Z"
+                error: "Application initialization failed"
+                
+  /ready:
+    get:
+      tags:
+        - Health
+      summary: Readiness probe
+      description: |
+        Checks if the application is ready to accept traffic. Used by Kubernetes 
+        readiness probes to control load balancer routing. Returns 503 if any 
+        critical dependency is unavailable.
+      operationId: getReadiness
+      responses:
+        '200':
+          description: Service is ready to accept traffic
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Cache-Control:
+              schema:
+                type: string
+                example: no-cache, no-store, must-revalidate
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadinessOk'
+              example:
+                status: ready
+                timestamp: "2026-01-07T10:30:00Z"
+                checks:
+                  database:
+                    status: ok
+                    response_time_ms: 12
+                  redis:
+                    status: ok
+                    response_time_ms: 5
+                  guardian_service:
+                    status: ok
+                    response_time_ms: 45
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Rate limit exceeded"
+                timestamp: "2026-01-07T10:30:00Z"
+        '503':
+          description: Service not ready (critical dependencies down)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadinessNotReady'
+              example:
+                status: not_ready
+                timestamp: "2026-01-07T10:30:00Z"
+                checks:
+                  database:
+                    status: ok
+                    response_time_ms: 12
+                  guardian_service:
+                    status: error
+                    response_time_ms: 5000
+                    error: "Connection refused"
+
+  /version:
+    get:
+      tags:
+        - Version
+      summary: Get service version
+      description: |
+        Returns the service version, commit hash, and build information. 
+        Version is read from VERSION file at repository root.
+      operationId: getVersion
+      responses:
+        '200':
+          description: Version information retrieved successfully
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Cache-Control:
+              schema:
+                type: string
+                example: public, max-age=300
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Version'
+              example:
+                version: "1.2.3"
+                commit: "abc123def456"
+                build_date: "2026-01-07T08:00:00Z"
+                environment: "production"
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Rate limit exceeded"
+                timestamp: "2026-01-07T10:30:00Z"
+        '500':
+          description: Failed to read version information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionError'
+              example:
+                error: "VERSION file not found"
+                timestamp: "2026-01-07T10:30:00Z"
+
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - error
+        - timestamp
+      properties:
+        error:
+          type: string
+          description: Error message
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp in UTC
+    HealthOk:
+      type: object
+      required:
+        - status
+        - timestamp
+        - checks
+      properties:
+        status:
+          type: string
+          enum: [ok]
+          description: Service health status
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp in UTC
+        checks:
+          type: object
+          description: Health check results for dependencies
+          properties:
+            database:
+              $ref: '#/components/schemas/CheckResult'
+          additionalProperties:
+            $ref: '#/components/schemas/CheckResult'
+            
+    HealthDegraded:
+      type: object
+      required:
+        - status
+        - timestamp
+        - checks
+      properties:
+        status:
+          type: string
+          enum: [degraded]
+          description: Service is alive but dependencies are failing
+        timestamp:
+          type: string
+          format: date-time
+        checks:
+          type: object
+          properties:
+            database:
+              $ref: '#/components/schemas/CheckResultError'
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/CheckResult'
+              - $ref: '#/components/schemas/CheckResultError'
+              
+    HealthError:
+      type: object
+      required:
+        - status
+        - timestamp
+        - error
+      properties:
+        status:
+          type: string
+          enum: [error]
+        timestamp:
+          type: string
+          format: date-time
+        error:
+          type: string
+          description: Error message describing what failed
+          
+    ReadinessOk:
+      type: object
+      required:
+        - status
+        - timestamp
+        - checks
+      properties:
+        status:
+          type: string
+          enum: [ready]
+        timestamp:
+          type: string
+          format: date-time
+        checks:
+          type: object
+          description: Readiness check results for all critical dependencies
+          properties:
+            database:
+              $ref: '#/components/schemas/CheckResult'
+            redis:
+              $ref: '#/components/schemas/CheckResult'
+            guardian_service:
+              $ref: '#/components/schemas/CheckResult'
+            identity_service:
+              $ref: '#/components/schemas/CheckResult'
+          additionalProperties:
+            $ref: '#/components/schemas/CheckResult'
+            
+    ReadinessNotReady:
+      type: object
+      required:
+        - status
+        - timestamp
+        - checks
+      properties:
+        status:
+          type: string
+          enum: [not_ready]
+        timestamp:
+          type: string
+          format: date-time
+        checks:
+          type: object
+          properties:
+            database:
+              oneOf:
+                - $ref: '#/components/schemas/CheckResult'
+                - $ref: '#/components/schemas/CheckResultError'
+            redis:
+              oneOf:
+                - $ref: '#/components/schemas/CheckResult'
+                - $ref: '#/components/schemas/CheckResultError'
+            guardian_service:
+              oneOf:
+                - $ref: '#/components/schemas/CheckResult'
+                - $ref: '#/components/schemas/CheckResultError'
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/CheckResult'
+              - $ref: '#/components/schemas/CheckResultError'
+              
+    CheckResult:
+      type: object
+      required:
+        - status
+        - response_time_ms
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        response_time_ms:
+          type: integer
+          minimum: 0
+          description: Check execution time in milliseconds
+          
+    CheckResultError:
+      type: object
+      required:
+        - status
+        - response_time_ms
+      properties:
+        status:
+          type: string
+          enum: [error]
+        response_time_ms:
+          type: integer
+          minimum: 0
+        error:
+          type: string
+          description: Error message describing the failure
+          
+    Version:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: string
+          pattern: '^\d+\.\d+\.\d+$'
+          description: Semantic version (MAJOR.MINOR.PATCH)
+          example: "1.2.3"
+        commit:
+          type: string
+          description: Git commit hash (short format)
+          example: "abc123def456"
+        build_date:
+          type: string
+          format: date-time
+          description: ISO 8601 build timestamp
+        environment:
+          type: string
+          enum: [development, testing, staging, production]
+          description: Deployment environment
+          
+    VersionError:
+      type: object
+      required:
+        - error
+        - timestamp
+      properties:
+        error:
+          type: string
+          description: Error message
+        timestamp:
+          type: string
+          format: date-time

--- a/openapi/health-endpoints.yaml
+++ b/openapi/health-endpoints.yaml
@@ -9,8 +9,8 @@ info:
   contact:
     name: Backend Team
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: AGPLv3 or Commercial (dual licensing)
+    url: https://www.gnu.org/licenses/agpl-3.0.en.html
     
 servers:
   - url: http://localhost:5000

--- a/openapi/metrics-endpoint.yaml
+++ b/openapi/metrics-endpoint.yaml
@@ -1,0 +1,185 @@
+openapi: 3.0.3
+info:
+  title: Prometheus Metrics Endpoint
+  description: |
+    Exposes application, HTTP, and system metrics in Prometheus text exposition format 
+    for scraping by Prometheus monitoring server. Requires API key authentication.
+  version: 1.0.0
+  contact:
+    name: Backend Team
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  - url: http://localhost:5000
+    description: Development server
+  - url: https://api-staging.waterfall.com
+    description: Staging server
+  - url: https://api.waterfall.com
+    description: Production server
+
+tags:
+  - name: Metrics
+    description: Prometheus metrics exposition
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /metrics:
+    get:
+      tags:
+        - Metrics
+      summary: Get Prometheus metrics
+      description: |
+        Exposes application metrics in Prometheus text exposition format. 
+        Requires API key authentication via Authorization header. Scraped by 
+        Prometheus server at configured interval (typically 15-60 seconds).
+        
+        **Metrics included:**
+        - HTTP request count, duration histograms, status codes
+        - System metrics (CPU, memory, threads)
+        - Database connection pool metrics
+        - Python runtime information
+      operationId: getMetrics
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Metrics retrieved successfully
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                example: text/plain; version=0.0.4; charset=utf-8
+              description: Prometheus text exposition format
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Prometheus text exposition format
+              examples:
+                full:
+                  $ref: '#/components/examples/PrometheusMetrics'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_key:
+                  summary: Authorization header missing
+                  value:
+                    message: "Missing Authorization header"
+                    timestamp: "2026-01-07T10:30:00Z"
+                invalid_key:
+                  summary: Invalid API key
+                  value:
+                    message: "Invalid API key"
+                    timestamp: "2026-01-07T10:30:00Z"
+        '429':
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Rate limit exceeded. Maximum 10 requests per minute."
+                timestamp: "2026-01-07T10:30:00Z"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Failed to collect metrics"
+                timestamp: "2026-01-07T10:30:00Z"
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: |
+        API key authentication via Authorization header.
+        Format: Authorization: Bearer <METRICS_API_KEY>
+        
+        The API key is configured via the `METRICS_API_KEY` environment variable 
+        and must be at least 32 characters alphanumeric.
+
+  headers:
+    X-RateLimit-Limit:
+      description: Maximum requests per minute
+      schema:
+        type: integer
+        example: 10
+    X-RateLimit-Remaining:
+      description: Remaining requests in current window
+      schema:
+        type: integer
+        example: 9
+    X-RateLimit-Reset:
+      description: Unix timestamp when limit resets
+      schema:
+        type: integer
+        format: int64
+        example: 1704628800
+
+  schemas:
+    Error:
+      type: object
+      required:
+        - message
+        - timestamp
+      properties:
+        message:
+          type: string
+          description: Human-readable error message
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp in UTC
+          
+  examples:
+    PrometheusMetrics:
+      summary: Complete metrics response
+      description: Example of all metrics exposed by the endpoint
+      value: |
+        # HELP python_info Python platform information
+        # TYPE python_info gauge
+        python_info{implementation="CPython",major="3",minor="11",patchlevel="7",version="3.11.7"} 1.0
+        
+        # HELP flask_http_request_duration_seconds Flask HTTP request duration in seconds
+        # TYPE flask_http_request_duration_seconds histogram
+        flask_http_request_duration_seconds_bucket{le="0.005",method="GET",path="/v0/dummies",status="200"} 145.0
+        flask_http_request_duration_seconds_count{method="GET",path="/v0/dummies",status="200"} 350.0
+        flask_http_request_duration_seconds_sum{method="GET",path="/v0/dummies",status="200"} 8.75
+        
+        # HELP flask_http_request_total Total number of HTTP requests
+        # TYPE flask_http_request_total counter
+        flask_http_request_total{method="GET",status="200"} 1234.0
+        
+        # HELP process_virtual_memory_bytes Virtual memory size in bytes
+        # TYPE process_virtual_memory_bytes gauge
+        process_virtual_memory_bytes 234567890.0
+        
+        # HELP sqlalchemy_pool_size Current size of the connection pool
+        # TYPE sqlalchemy_pool_size gauge
+        sqlalchemy_pool_size 5.0

--- a/openapi/metrics-endpoint.yaml
+++ b/openapi/metrics-endpoint.yaml
@@ -8,8 +8,8 @@ info:
   contact:
     name: Backend Team
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: AGPL-3.0-or-later / Commercial
+    url: https://www.gnu.org/licenses/agpl-3.0.en.html
 
 servers:
   - url: http://localhost:5000

--- a/spec/schema-api-dummies-crud.md
+++ b/spec/schema-api-dummies-crud.md
@@ -1,0 +1,1213 @@
+---
+title: Dummies CRUD API Specification
+version: 1.0
+date_created: 2026-01-07
+last_updated: 2026-01-07
+owner: Backend Team
+tags: [api, crud, example, template, authentication, authorization]
+---
+
+# Introduction
+
+This specification defines a complete CRUD API for the "Dummy" resource, serving as an example implementation in the wfp-flask-template. This resource demonstrates all standard patterns: JWT authentication, Guardian authorization, multi-tenancy isolation, pagination, validation, and error handling.
+
+## 1. Purpose & Scope
+
+**Purpose:**
+- Provide a reference implementation for CRUD endpoints in Waterfall microservices
+- Demonstrate authentication, authorization, and multi-tenancy patterns
+- Serve as a starting point for new resource implementations
+- Enable testing and validation of the template architecture
+
+**Scope:**
+- Five CRUD endpoints: List, Create, Retrieve, Update, Delete
+- JWT authentication required for all endpoints
+- Guardian authorization with LIST, CREATE, READ, UPDATE, DELETE operations
+- Multi-tenancy isolation by company_id
+- Pagination and sorting for list endpoint
+- Comprehensive validation and error handling
+
+**Target Audience:**
+- Backend developers implementing new resources
+- API consumers testing the service
+- DevOps teams validating deployments
+
+**Assumptions:**
+- JWT token contains `user_id`, `company_id`, `email` claims
+- Guardian service is available and configured
+- PostgreSQL database with dummies table
+- Users can only access dummies within their company
+
+## 2. Definitions
+
+| Term | Definition |
+|------|------------|
+| Dummy | Example resource entity for demonstration purposes |
+| Multi-tenancy | Data isolation ensuring users only see their company's data |
+| Soft Delete | Setting is_active=false instead of physical deletion |
+| Guardian Context | Additional data sent to Guardian for authorization decisions |
+| Pagination | Splitting large result sets into smaller pages |
+
+## 3. Requirements, Constraints & Guidelines
+
+### Functional Requirements (REQ-xxx)
+
+**REQ-001**: API SHALL expose five CRUD endpoints for Dummy resource
+**REQ-002**: All endpoints SHALL be under `/v0/dummies` path with API versioning
+**REQ-003**: List endpoint SHALL support pagination with page, per_page parameters
+**REQ-004**: List endpoint SHALL support sorting with sort_by, sort_order parameters
+**REQ-005**: List endpoint SHALL return total count and total pages in response
+**REQ-006**: All endpoints SHALL filter dummies by company_id from JWT automatically
+**REQ-007**: Create/Update SHALL validate name field (3-255 characters, required)
+**REQ-008**: Update SHALL support partial updates (PATCH semantics)
+**REQ-009**: Delete SHALL perform soft delete (set is_active=false) and return 204 No Content
+**REQ-010**: Delete SHALL return 410 Gone if dummy already soft-deleted (is_active=false)
+**REQ-011**: Retrieve SHALL return 404 if dummy not found or belongs to another company
+**REQ-012**: All endpoints SHALL accept optional X-Correlation-ID request header
+**REQ-013**: All endpoints SHALL return X-Correlation-ID in response headers
+**REQ-014**: System SHALL auto-generate UUID correlation_id if not provided in request
+**REQ-015**: All log entries SHALL include correlation_id for request tracing
+**REQ-016**: Correlation ID SHALL be propagated to all downstream service calls (Guardian, etc.)
+**REQ-017**: Update endpoint SHALL NOT allow setting is_active=true (prevents reactivation via PATCH)
+
+### Security Requirements (SEC-xxx)
+
+**SEC-001**: All endpoints SHALL require valid JWT token via `access_token` cookie
+**SEC-002**: All endpoints SHALL verify Guardian permissions before processing
+**SEC-003**: List endpoint SHALL require Guardian LIST permission on "dummies" resource
+**SEC-004**: Create endpoint SHALL require Guardian CREATE permission
+**SEC-005**: Retrieve endpoint SHALL require Guardian READ permission
+**SEC-006**: Update endpoint SHALL require Guardian UPDATE permission
+**SEC-007**: Delete endpoint SHALL require Guardian DELETE permission
+**SEC-008**: Guardian context SHALL include company_id for all operations
+**SEC-009**: Guardian context SHALL include dummy_id for item operations (READ, UPDATE, DELETE)
+**SEC-010**: Endpoints SHALL enforce company_id isolation (users cannot access other companies' data)
+**SEC-011**: Endpoints SHALL rate limit to 100 requests per minute per user
+**SEC-012**: OpenAPI spec SHALL include `x-guardian-operation` extension for each endpoint to document required permissions
+
+### Performance Requirements (PERF-xxx)
+
+**PERF-001**: List endpoint SHALL respond in < 300ms for pages up to 100 items (99th percentile)
+**PERF-002**: Create endpoint SHALL respond in < 200ms (99th percentile)
+**PERF-003**: Retrieve endpoint SHALL respond in < 100ms (99th percentile)
+**PERF-004**: Update endpoint SHALL respond in < 200ms (99th percentile)
+**PERF-005**: Delete endpoint SHALL respond in < 150ms (99th percentile)
+**PERF-006**: Database SHALL have indexes on: company_id, created_at, name
+**PERF-007**: List queries SHALL use database-level pagination (LIMIT/OFFSET)
+
+### Constraints (CON-xxx)
+
+**CON-001**: API version prefix MUST be `/v0/` (not /v1/ yet)
+**CON-002**: All IDs MUST be UUIDs (not integers)
+**CON-003**: Dummy name MUST be unique per company (unique constraint)
+**CON-004**: Pagination per_page MUST NOT exceed 100 items
+**CON-005**: Soft-deleted dummies (is_active=false) MUST NOT appear in list results
+**CON-006**: Guardian service name MUST be "template-service"
+**CON-007**: Timestamps MUST be stored in UTC
+
+### Guidelines (GUD-xxx)
+
+**GUD-001**: Use UUIDMixin and TimestampMixin for model
+**GUD-002**: Create separate schemas: DummySchema, DummyCreateSchema, DummyUpdateSchema
+**GUD-003**: Use DummyListResource for GET /dummies and POST /dummies
+**GUD-004**: Use DummyResource for GET/PATCH/DELETE /dummies/{id}
+**GUD-005**: Place constants in app/constants/dummy_constants.py
+**GUD-006**: Log all Guardian authorization failures at WARNING level
+**GUD-007**: Return correlation_id in all error responses
+**GUD-008**: Use structured logging (JSON) with correlation_id field
+**GUD-009**: Log at appropriate levels: INFO (requests), WARNING (auth failures), ERROR (exceptions)
+**GUD-010**: Include correlation_id in all Guardian/Identity service calls for distributed tracing
+
+## 4. Interfaces & Data Contracts
+
+### 4.1 GET /v0/dummies - List Dummies
+
+**Endpoint:** `GET /v0/dummies`
+
+**Description:** Retrieve a paginated list of dummies for the authenticated user's company with optional sorting.
+
+#### Path Parameters
+None
+
+#### Query Parameters
+
+| Parameter | Type | Required | Default | Description | Validation |
+|-----------|------|----------|---------|-------------|------------|
+| page | integer | No | 1 | Page number (1-indexed) | min: 1 |
+| per_page | integer | No | 20 | Items per page | min: 1, max: 100 |
+| sort_by | string | No | created_at | Field to sort by | enum: name, created_at, updated_at |
+| sort_order | string | No | desc | Sort direction | enum: asc, desc |
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| Cookie | Yes | Must contain `access_token=<JWT>` |
+| X-Correlation-ID | No | Request correlation ID (UUID v4). Auto-generated if not provided |
+
+#### Request Body
+None
+
+#### Response Schemas
+
+**Success Response (200 OK):**
+
+```json
+{
+  "data": [
+    {
+      "id": "123e4567-e89b-12d3-a456-426614174000",
+      "name": "Example Dummy",
+      "description": "This is an example dummy resource",
+      "company_id": "987e6543-e21b-12d3-a456-426614174000",
+      "is_active": true,
+      "created_at": "2026-01-07T10:00:00Z",
+      "updated_at": "2026-01-07T10:00:00Z"
+    },
+    {
+      "id": "223e4567-e89b-12d3-a456-426614174001",
+      "name": "Another Dummy",
+      "description": null,
+      "company_id": "987e6543-e21b-12d3-a456-426614174000",
+      "is_active": true,
+      "created_at": "2026-01-07T09:30:00Z",
+      "updated_at": "2026-01-07T09:30:00Z"
+    }
+  ],
+  "page": 1,
+  "per_page": 20,
+  "total": 42,
+  "total_pages": 3
+}
+```
+
+**Success Response (200 OK - Empty):**
+
+```json
+{
+  "data": [],
+  "page": 1,
+  "per_page": 20,
+  "total": 0,
+  "total_pages": 0
+}
+```
+
+**Error Response (401 Unauthorized):**
+
+```json
+{
+  "message": "Missing or invalid JWT token",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (403 Forbidden):**
+
+```json
+{
+  "message": "Insufficient permissions to list dummies",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (422 Unprocessable Entity):**
+
+```json
+{
+  "message": "Validation failed",
+  "errors": {
+    "per_page": ["Must be less than or equal to 100"]
+  },
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Successful retrieval (even if empty) |
+| 401 | Unauthorized | Missing or invalid JWT token |
+| 403 | Forbidden | User lacks Guardian LIST permission |
+| 422 | Unprocessable Entity | Invalid query parameters |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Unexpected server error |
+
+---
+
+### 4.2 POST /v0/dummies - Create Dummy
+
+**Endpoint:** `POST /v0/dummies`
+
+**Description:** Create a new dummy resource for the authenticated user's company.
+
+#### Path Parameters
+None
+
+#### Query Parameters
+None
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| Cookie | Yes | Must contain `access_token=<JWT>` |
+| Content-Type | Yes | Must be `application/json` |
+| X-Correlation-ID | No | Request correlation ID (UUID v4). Auto-generated if not provided |
+
+#### Request Body Schema
+
+```json
+{
+  "name": {
+    "type": "string",
+    "required": true,
+    "minLength": 3,
+    "maxLength": 255,
+    "description": "Unique name for the dummy within the company"
+  },
+  "description": {
+    "type": "string",
+    "required": false,
+    "maxLength": 1000,
+    "description": "Optional description"
+  }
+}
+```
+
+**Example Request:**
+
+```json
+{
+  "name": "My New Dummy",
+  "description": "This is a test dummy resource"
+}
+```
+
+#### Response Schemas
+
+**Success Response (201 Created):**
+
+```json
+{
+  "data": {
+    "id": "323e4567-e89b-12d3-a456-426614174002",
+    "name": "My New Dummy",
+    "description": "This is a test dummy resource",
+    "company_id": "987e6543-e21b-12d3-a456-426614174000",
+    "is_active": true,
+    "created_at": "2026-01-07T11:00:00Z",
+    "updated_at": "2026-01-07T11:00:00Z"
+  },
+  "message": "Dummy created successfully"
+}
+```
+
+**Error Response (401 Unauthorized):**
+
+```json
+{
+  "message": "Missing or invalid JWT token",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (403 Forbidden):**
+
+```json
+{
+  "message": "Insufficient permissions to create dummies",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (409 Conflict):**
+
+```json
+{
+  "message": "Dummy with this name already exists in your company",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (422 Unprocessable Entity):**
+
+```json
+{
+  "message": "Validation failed",
+  "errors": {
+    "name": ["Field is required"],
+    "description": ["Length must be between 0 and 1000"]
+  },
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 201 | Created | Dummy successfully created |
+| 401 | Unauthorized | Missing or invalid JWT token |
+| 403 | Forbidden | User lacks Guardian CREATE permission |
+| 409 | Conflict | Dummy name already exists in company |
+| 422 | Unprocessable Entity | Validation errors |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Unexpected server error |
+
+---
+
+### 4.3 GET /v0/dummies/{id} - Retrieve Dummy
+
+**Endpoint:** `GET /v0/dummies/{id}`
+
+**Description:** Retrieve a single dummy by ID. Must belong to authenticated user's company.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | UUID | Yes | Dummy unique identifier |
+
+#### Query Parameters
+None
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| Cookie | Yes | Must contain `access_token=<JWT>` |
+| X-Correlation-ID | No | Request correlation ID (UUID v4). Auto-generated if not provided |
+
+#### Request Body
+None
+
+#### Response Schemas
+
+**Success Response (200 OK):**
+
+```json
+{
+  "data": {
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "name": "Example Dummy",
+    "description": "This is an example dummy resource",
+    "company_id": "987e6543-e21b-12d3-a456-426614174000",
+    "is_active": true,
+    "created_at": "2026-01-07T10:00:00Z",
+    "updated_at": "2026-01-07T10:00:00Z"
+  }
+}
+```
+
+**Error Response (401 Unauthorized):**
+
+```json
+{
+  "message": "Missing or invalid JWT token",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (403 Forbidden):**
+
+```json
+{
+  "message": "Insufficient permissions to read this dummy",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (404 Not Found):**
+
+```json
+{
+  "message": "Dummy not found",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Dummy found and returned |
+| 401 | Unauthorized | Missing or invalid JWT token |
+| 403 | Forbidden | User lacks Guardian READ permission |
+| 404 | Not Found | Dummy not found or belongs to another company |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Unexpected server error |
+
+---
+
+### 4.4 PATCH /v0/dummies/{id} - Update Dummy
+
+**Endpoint:** `PATCH /v0/dummies/{id}`
+
+**Description:** Partially update a dummy. Only provided fields are updated. Must belong to authenticated user's company.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | UUID | Yes | Dummy unique identifier |
+
+#### Query Parameters
+None
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| Cookie | Yes | Must contain `access_token=<JWT>` |
+| Content-Type | Yes | Must be `application/json` |
+| X-Correlation-ID | No | Request correlation ID (UUID v4). Auto-generated if not provided |
+
+#### Request Body Schema
+
+```json
+{
+  "name": {
+    "type": "string",
+    "required": false,
+    "minLength": 3,
+    "maxLength": 255,
+    "description": "Updated name (must be unique in company)"
+  },
+  "description": {
+    "type": "string",
+    "required": false,
+    "maxLength": 1000,
+    "description": "Updated description (null to clear)"
+  },
+  "is_active": {
+    "type": "boolean",
+    "required": false,
+    "enum": [false],
+    "description": "Active status. Can only be set to false (soft delete). Use DELETE endpoint instead. Cannot reactivate via PATCH."
+  }
+}
+```
+
+**Example Request (Partial Update):**
+
+```json
+{
+  "name": "Updated Dummy Name"
+}
+```
+
+**Example Request (Multiple Fields):**
+
+```json
+{
+  "name": "Completely Updated",
+  "description": "New description here",
+  "is_active": false
+}
+```
+
+#### Response Schemas
+
+**Success Response (200 OK):**
+
+```json
+{
+  "data": {
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "name": "Updated Dummy Name",
+    "description": "This is an example dummy resource",
+    "company_id": "987e6543-e21b-12d3-a456-426614174000",
+    "is_active": true,
+    "created_at": "2026-01-07T10:00:00Z",
+    "updated_at": "2026-01-07T11:30:00Z"
+  },
+  "message": "Dummy updated successfully"
+}
+```
+
+**Error Response (401 Unauthorized):**
+
+```json
+{
+  "message": "Missing or invalid JWT token",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (403 Forbidden):**
+
+```json
+{
+  "message": "Insufficient permissions to update this dummy",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (404 Not Found):**
+
+```json
+{
+  "message": "Dummy not found",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (409 Conflict):**
+
+```json
+{
+  "message": "Dummy with this name already exists in your company",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (422 Unprocessable Entity):**
+
+```json
+{
+  "message": "Validation failed",
+  "errors": {
+    "name": ["Length must be between 3 and 255"]
+  },
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Dummy successfully updated |
+| 401 | Unauthorized | Missing or invalid JWT token |
+| 403 | Forbidden | User lacks Guardian UPDATE permission |
+| 404 | Not Found | Dummy not found or belongs to another company |
+| 409 | Conflict | Updated name conflicts with existing dummy |
+| 422 | Unprocessable Entity | Validation errors |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Unexpected server error |
+
+---
+
+### 4.5 DELETE /v0/dummies/{id} - Delete Dummy
+
+**Endpoint:** `DELETE /v0/dummies/{id}`
+
+**Description:** Soft delete a dummy (set is_active=false). Must belong to authenticated user's company.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | UUID | Yes | Dummy unique identifier |
+
+#### Query Parameters
+None
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| Cookie | Yes | Must contain `access_token=<JWT>` |
+| X-Correlation-ID | No | Request correlation ID (UUID v4). Auto-generated if not provided |
+
+#### Response Schemas
+
+**Success Response (204 No Content):**
+
+No response body. Headers only (X-Correlation-ID, X-RateLimit-*).
+
+**Error Response (401 Unauthorized):**
+
+```json
+{
+  "message": "Missing or invalid JWT token",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (403 Forbidden):**
+
+```json
+{
+  "message": "Insufficient permissions to delete this dummy",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (404 Not Found):**
+
+```json
+{
+  "message": "Dummy not found",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Error Response (410 Gone):**
+
+```json
+{
+  "message": "Dummy has already been deleted",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 204 | No Content | Dummy successfully deleted (soft delete) |
+| 401 | Unauthorized | Missing or invalid JWT token |
+| 403 | Forbidden | User lacks Guardian DELETE permission |
+| 404 | Not Found | Dummy not found or belongs to another company |
+| 410 | Gone | Dummy has already been soft-deleted (is_active=false) |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Unexpected server error |
+
+---
+
+### Response Headers (All Endpoints)
+
+| Header | Description | When |
+|--------|-------------|------|
+| Content-Type | application/json | All responses |
+| X-Correlation-ID | Request correlation ID (from request or auto-generated) | All responses (success & errors) |
+| X-RateLimit-Limit | Maximum requests per window | All responses |
+| X-RateLimit-Remaining | Remaining requests in current window | All responses |
+| X-RateLimit-Reset | Unix timestamp when limit resets | All responses |
+
+**Example Response Headers:**
+```
+Content-Type: application/json
+X-Correlation-ID: 550e8400-e29b-41d4-a716-446655440000
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 95
+X-RateLimit-Reset: 1704628800
+```
+
+## 5. Acceptance Criteria
+
+### AC-001: List Dummies with Pagination
+- **Given** user has valid JWT token and Guardian LIST permission
+- **And** company has 50 dummies
+- **When** GET /v0/dummies?page=2&per_page=20 is called
+- **Then** response status is 200
+- **And** response contains 20 dummies (items 21-40)
+- **And** pagination metadata shows page=2, per_page=20, total=50, total_pages=3
+- **And** only dummies with is_active=true are returned
+- **And** all dummies have matching company_id from JWT
+
+### AC-002: Create Dummy Successfully
+- **Given** user has valid JWT token and Guardian CREATE permission
+- **When** POST /v0/dummies with valid data
+- **Then** response status is 201
+- **And** response contains new dummy with generated UUID
+- **And** dummy.company_id matches company_id from JWT
+- **And** dummy.is_active is true by default
+- **And** created_at and updated_at are set to current UTC time
+
+### AC-003: Create Duplicate Name in Same Company
+- **Given** dummy with name "Test" exists in company A
+- **And** user belongs to company A
+- **When** POST /v0/dummies with name "Test"
+- **Then** response status is 409 Conflict
+- **And** error message indicates name already exists
+
+### AC-004: Create Same Name in Different Company (Allowed)
+- **Given** dummy with name "Test" exists in company A
+- **And** user belongs to company B
+- **When** POST /v0/dummies with name "Test"
+- **Then** response status is 201
+- **And** dummy is created successfully in company B
+
+### AC-005: Retrieve Dummy from Same Company
+- **Given** dummy with id=123 exists in company A
+- **And** user belongs to company A with READ permission
+- **When** GET /v0/dummies/123
+- **Then** response status is 200
+- **And** response contains full dummy data
+
+### AC-006: Retrieve Dummy from Different Company
+- **Given** dummy with id=123 exists in company A
+- **And** user belongs to company B
+- **When** GET /v0/dummies/123
+- **Then** response status is 404 Not Found
+- **And** no company information is leaked
+
+### AC-007: Update Dummy Partially
+- **Given** dummy exists with name="Old" and description="Old desc"
+- **And** user has UPDATE permission
+- **When** PATCH /v0/dummies/{id} with {"name": "New"}
+- **Then** response status is 200
+- **And** dummy.name is "New"
+- **And** dummy.description remains "Old desc" (unchanged)
+- **And** dummy.updated_at is updated to current time
+
+### AC-008: Soft Delete Dummy
+- **Given** dummy exists with is_active=true
+- **And** user has DELETE permission
+- **When** DELETE /v0/dummies/{id}
+- **Then** response status is 200
+- **And** dummy.is_active is set to false
+- **And** dummy no longer appears in GET /v0/dummies list
+- **And** dummy can still be retrieved by ID (returns is_active=false)
+
+### AC-009: Guardian Authorization Failure
+- **Given** user has valid JWT token
+- **And** Guardian denies CREATE permission
+- **When** POST /v0/dummies with valid data
+- **Then** response status is 403 Forbidden
+- **And** no dummy is created
+- **And** authorization failure is logged
+
+### AC-010: Invalid JWT Token
+- **Given** no JWT token provided in cookie
+- **When** any endpoint is called
+- **Then** response status is 401 Unauthorized
+- **And** response contains authentication error message
+
+### AC-011: Pagination with Sorting
+- **Given** company has dummies with names "C", "A", "B"
+- **When** GET /v0/dummies?sort_by=name&sort_order=asc
+- **Then** response status is 200
+- **And** dummies are returned in order: "A", "B", "C"
+
+### AC-012: Rate Limiting
+- **Given** user makes 100 requests in 1 minute
+- **When** 101st request is made
+- **Then** response status is 429 Too Many Requests
+- **And** X-RateLimit-Reset header indicates when limit resets
+
+## 6. Test Automation Strategy
+
+**Test Levels:**
+- Unit tests: Model validation, schema serialization, business logic
+- Integration tests: Database operations, Guardian integration, full endpoint flows
+- End-to-end tests: Complete CRUD workflows with authentication
+
+**Frameworks:**
+- pytest for all test levels
+- FlaskClient for endpoint testing
+- pytest-mock for Guardian mocking in unit tests
+- Docker Compose for integration test database
+
+**Test Data Management:**
+- Factory pattern for creating test dummies
+- Fixtures for JWT tokens with different permissions
+- Database transaction rollback after each test
+- Separate test database schema
+
+**CI/CD Integration:**
+- Run on every commit and PR
+- Required for merge approval
+- Coverage report in PR comments
+- Integration tests run against PostgreSQL container
+
+**Coverage Requirements:**
+- Minimum 85% overall code coverage
+- 100% coverage for critical paths (authentication, authorization)
+- All status codes tested for each endpoint
+- All validation rules tested
+
+**Performance Testing:**
+- Load test with 100 concurrent users
+- Verify response times meet requirements
+- Test pagination with 10,000 records
+- Measure Guardian integration latency
+
+## 7. Logging Strategy
+
+### Log Levels
+
+| Level | When to Use | Examples |
+|-------|-------------|----------|
+| INFO | Normal operations | Request received, request completed, Guardian check passed |
+| WARNING | Recoverable issues | Guardian denied permission, validation failed, rate limit exceeded |
+| ERROR | Unexpected failures | Database connection failed, Guardian service unreachable, unhandled exception |
+| DEBUG | Development/troubleshooting | Request/response bodies, SQL queries, Guardian request/response |
+
+### Required Log Fields
+
+All log entries MUST include (structured JSON format):
+
+```json
+{
+  "timestamp": "2026-01-07T12:00:00.123Z",
+  "level": "INFO",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000",
+  "user_id": "user-uuid",
+  "company_id": "company-uuid",
+  "method": "POST",
+  "path": "/v0/dummies",
+  "status_code": 201,
+  "duration_ms": 45,
+  "message": "Dummy created successfully"
+}
+```
+
+### Log Examples by Operation
+
+**Successful Request:**
+```json
+{
+  "timestamp": "2026-01-07T12:00:00.123Z",
+  "level": "INFO",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000",
+  "user_id": "user-123",
+  "company_id": "company-456",
+  "method": "POST",
+  "path": "/v0/dummies",
+  "status_code": 201,
+  "duration_ms": 45,
+  "message": "Request completed",
+  "dummy_id": "dummy-789"
+}
+```
+
+**Authorization Failure:**
+```json
+{
+  "timestamp": "2026-01-07T12:01:00.456Z",
+  "level": "WARNING",
+  "correlation_id": "650e8400-e29b-41d4-a716-446655440001",
+  "user_id": "user-123",
+  "company_id": "company-456",
+  "method": "POST",
+  "path": "/v0/dummies",
+  "status_code": 403,
+  "duration_ms": 120,
+  "message": "Guardian denied CREATE permission",
+  "guardian_reason": "no_permission",
+  "guardian_operation": "CREATE",
+  "guardian_resource": "dummies"
+}
+```
+
+**Service Error:**
+```json
+{
+  "timestamp": "2026-01-07T12:02:00.789Z",
+  "level": "ERROR",
+  "correlation_id": "750e8400-e29b-41d4-a716-446655440002",
+  "user_id": "user-123",
+  "company_id": "company-456",
+  "method": "GET",
+  "path": "/v0/dummies",
+  "status_code": 500,
+  "duration_ms": 5000,
+  "message": "Guardian service timeout",
+  "error_type": "ConnectionTimeout",
+  "service": "guardian",
+  "stack_trace": "..."
+}
+```
+
+### Distributed Tracing
+
+**Correlation ID Propagation:**
+- Accept X-Correlation-ID from incoming request
+- Generate UUID v4 if not provided
+- Include in all outgoing service calls (Guardian, Identity, etc.)
+- Return in X-Correlation-ID response header
+- Log in every log entry for the request lifecycle
+
+**Service Call Example:**
+```python
+# Propagate correlation_id to Guardian
+headers = {
+    "Authorization": "Bearer <token>",
+    "X-Correlation-ID": correlation_id
+}
+response = requests.post(guardian_url, headers=headers, json=payload)
+```
+
+## 8. Rationale & Context
+
+**Why soft delete instead of hard delete?**
+- Maintains audit trail and data history
+- Allows potential data recovery
+- Prevents foreign key constraint violations
+- Industry best practice for user-facing deletions
+
+**Why unique constraint on (name, company_id)?**
+- Prevents duplicate names within a company
+- Allows same names across different companies (multi-tenancy)
+- Provides clear validation error for users
+- Database-enforced consistency
+
+**Why company_id in all queries?**
+- Enforces multi-tenancy isolation at database level
+- Prevents accidental data leaks between companies
+- Performance: allows index on company_id
+- Security defense in depth
+
+**Why separate Guardian check for each operation?**
+- Fine-grained permission control (user can LIST but not CREATE)
+- Follows principle of least privilege
+- Allows role-based access control
+- Audit trail of authorization decisions
+
+**Why pagination default to 20 items?**
+- Balance between user experience and performance
+- Prevents accidentally loading thousands of records
+- Standard REST API practice
+- Allows fast response times
+
+**Why return 404 for cross-company access?**
+- Prevents information disclosure (dummy exists or not)
+- Consistent with "not found" from user perspective
+- Security best practice (don't leak existence)
+- Simpler client error handling
+
+## 9. Dependencies & External Integrations
+
+### External Systems
+- **EXT-001**: Guardian Service - Authorization service checking permissions
+  - Endpoint: `/check-access`
+  - Required for all CRUD operations
+  - Context includes: service="template-service", resource="dummies", operation, company_id, dummy_id
+
+- **EXT-002**: Identity Service - JWT token validation
+  - Validates JWT signature and expiration
+  - Provides user_id, company_id, email claims
+
+### Infrastructure Dependencies
+- **INF-001**: PostgreSQL Database - Primary data store
+  - Table: dummies
+  - Indexes: company_id, created_at, (name, company_id) unique
+
+- **INF-002**: Redis (Optional) - Rate limiting storage
+  - Tracks request counts per user/IP
+  - TTL for rate limit windows
+
+### Technology Platform Dependencies
+- **PLT-001**: Flask web framework - HTTP request handling
+- **PLT-002**: SQLAlchemy - ORM and database operations
+- **PLT-003**: Marshmallow - Schema validation and serialization
+- **PLT-004**: Flask-RESTful - Resource class base
+- **PLT-005**: Python 3.11+ - Runtime environment
+
+### Data Dependencies
+- **DAT-001**: JWT Token - Contains user_id, company_id, email
+- **DAT-002**: Guardian Configuration - Service and resource definitions
+
+## 10. Examples & Edge Cases
+
+### Example 1: Complete CRUD Workflow
+```bash
+# 1. Create dummy
+curl -X POST http://localhost:5000/v0/dummies \
+  -H "Content-Type: application/json" \
+  -b "access_token=<jwt>" \
+  -d '{"name": "Test Dummy", "description": "Testing"}'
+
+# Response: 201 Created
+{
+  "data": {
+    "id": "abc-123",
+    "name": "Test Dummy",
+    "description": "Testing",
+    "company_id": "company-xyz",
+    "is_active": true,
+    "created_at": "2026-01-07T12:00:00Z",
+    "updated_at": "2026-01-07T12:00:00Z"
+  },
+  "message": "Dummy created successfully"
+}
+
+# 2. List dummies
+curl http://localhost:5000/v0/dummies?page=1&per_page=10 \
+  -b "access_token=<jwt>"
+
+# Response: 200 OK
+{
+  "data": [{"id": "abc-123", "name": "Test Dummy", ...}],
+  "page": 1,
+  "per_page": 10,
+  "total": 1,
+  "total_pages": 1
+}
+
+# 3. Retrieve single dummy
+curl http://localhost:5000/v0/dummies/abc-123 \
+  -b "access_token=<jwt>"
+
+# Response: 200 OK
+{
+  "data": {"id": "abc-123", "name": "Test Dummy", ...}
+}
+
+# 4. Update dummy
+curl -X PATCH http://localhost:5000/v0/dummies/abc-123 \
+  -H "Content-Type: application/json" \
+  -b "access_token=<jwt>" \
+  -d '{"name": "Updated Name"}'
+
+# Response: 200 OK
+{
+  "data": {"id": "abc-123", "name": "Updated Name", ...},
+  "message": "Dummy updated successfully"
+}
+
+# 5. Delete dummy
+curl -X DELETE http://localhost:5000/v0/dummies/abc-123 \
+  -b "access_token=<jwt>"
+
+# Response: 200 OK
+{
+  "message": "Dummy deleted successfully"
+}
+
+# 6. Verify deletion (soft delete)
+curl http://localhost:5000/v0/dummies \
+  -b "access_token=<jwt>"
+
+# Response: 200 OK (deleted dummy not in list)
+{
+  "data": [],
+  "page": 1,
+  "per_page": 20,
+  "total": 0,
+  "total_pages": 0
+}
+```
+
+### Example 2: Validation Errors
+```bash
+# Missing required field
+curl -X POST http://localhost:5000/v0/dummies \
+  -H "Content-Type: application/json" \
+  -b "access_token=<jwt>" \
+  -d '{"description": "No name provided"}'
+
+# Response: 422 Unprocessable Entity
+{
+  "message": "Validation failed",
+  "errors": {
+    "name": ["Field is required"]
+  },
+  "correlation_id": "xyz-789"
+}
+
+# Name too short
+curl -X POST http://localhost:5000/v0/dummies \
+  -H "Content-Type: application/json" \
+  -b "access_token=<jwt>" \
+  -d '{"name": "AB"}'
+
+# Response: 422 Unprocessable Entity
+{
+  "message": "Validation failed",
+  "errors": {
+    "name": ["Length must be between 3 and 255"]
+  },
+  "correlation_id": "xyz-790"
+}
+```
+
+### Example 3: Multi-Tenancy Isolation
+```bash
+# User A in Company 1 creates dummy
+curl -X POST http://localhost:5000/v0/dummies \
+  -H "Content-Type: application/json" \
+  -b "access_token=<jwt-company-1>" \
+  -d '{"name": "Company 1 Dummy"}'
+
+# Response: 201 Created (id=123, company_id=company-1)
+
+# User B in Company 2 tries to access Company 1's dummy
+curl http://localhost:5000/v0/dummies/123 \
+  -b "access_token=<jwt-company-2>"
+
+# Response: 404 Not Found (cross-company access blocked)
+{
+  "message": "Dummy not found",
+  "correlation_id": "xyz-791"
+}
+
+# User B lists dummies (sees only their company's data)
+curl http://localhost:5000/v0/dummies \
+  -b "access_token=<jwt-company-2>"
+
+# Response: 200 OK (empty, no Company 1 data visible)
+{
+  "data": [],
+  "page": 1,
+  "per_page": 20,
+  "total": 0,
+  "total_pages": 0
+}
+```
+
+### Edge Case 1: Guardian Service Down
+```bash
+curl -X POST http://localhost:5000/v0/dummies \
+  -H "Content-Type: application/json" \
+  -b "access_token=<jwt>" \
+  -d '{"name": "Test"}'
+
+# Response: 500 Internal Server Error
+{
+  "message": "Authorization service unavailable",
+  "correlation_id": "xyz-792"
+}
+```
+
+### Edge Case 2: Pagination Beyond Last Page
+```bash
+# Only 10 dummies exist, request page 5
+curl "http://localhost:5000/v0/dummies?page=5&per_page=20" \
+  -b "access_token=<jwt>"
+
+# Response: 200 OK (empty page, valid request)
+{
+  "data": [],
+  "page": 5,
+  "per_page": 20,
+  "total": 10,
+  "total_pages": 1
+}
+```
+
+### Edge Case 3: Concurrent Update Conflict
+```bash
+# User A and User B update same dummy simultaneously
+# Last write wins, both succeed with 200 OK
+# updated_at timestamp shows most recent update
+```
+
+### Edge Case 4: Invalid UUID Format
+```bash
+curl http://localhost:5000/v0/dummies/not-a-uuid \
+  -b "access_token=<jwt>"
+
+# Response: 404 Not Found (Flask route doesn't match)
+# Or 422 Unprocessable Entity if route matches but UUID validation fails
+```
+
+## 11. Validation Criteria
+
+- **VAL-001**: All endpoints return valid JSON (validated with jsonschema)
+- **VAL-002**: JWT authentication rejects missing or invalid tokens with 401
+- **VAL-003**: Guardian authorization failures return 403 with clear message
+- **VAL-004**: Multi-tenancy isolation: users never see other companies' data
+- **VAL-005**: Pagination calculates total_pages correctly: ceil(total / per_page)
+- **VAL-006**: Soft delete sets is_active=false and removes from list results
+- **VAL-007**: Unique constraint (name, company_id) enforced at database level
+- **VAL-008**: All validation errors return 422 with field-specific messages
+- **VAL-009**: All timestamps stored and returned in UTC ISO 8601 format
+- **VAL-010**: Response times meet performance requirements (PERF-001 to PERF-005)
+- **VAL-011**: Rate limiting enforces 100 requests per minute per user
+- **VAL-012**: Correlation ID present in all error responses
+
+## 11. Related Specifications / Further Reading
+
+- spec/schema-api-health-endpoints.md - Health check endpoints
+- spec/schema-api-metrics-endpoint.md - Prometheus metrics endpoint
+- [Guardian Service API Documentation](../docs/guardian-integration.md)
+- [Identity Service JWT Claims](../docs/jwt-authentication.md)
+- [REST API Best Practices](https://restfulapi.net/)
+- [HTTP Status Codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)
+- [UUID v4 Specification](https://datatracker.ietf.org/doc/html/rfc4122)

--- a/spec/schema-api-dummies-crud.md
+++ b/spec/schema-api-dummies-crud.md
@@ -749,7 +749,7 @@ X-RateLimit-Reset: 1704628800
 - **Given** dummy exists with is_active=true
 - **And** user has DELETE permission
 - **When** DELETE /v0/dummies/{id}
-- **Then** response status is 200
+- **Then** response status is 204
 - **And** dummy.is_active is set to false
 - **And** dummy no longer appears in GET /v0/dummies list
 - **And** dummy can still be retrieved by ID (returns is_active=false)

--- a/spec/schema-api-dummies-crud.md
+++ b/spec/schema-api-dummies-crud.md
@@ -1202,7 +1202,7 @@ curl http://localhost:5000/v0/dummies/not-a-uuid \
 - **VAL-011**: Rate limiting enforces 100 requests per minute per user
 - **VAL-012**: Correlation ID present in all error responses
 
-## 11. Related Specifications / Further Reading
+## 12. Related Specifications / Further Reading
 
 - spec/schema-api-health-endpoints.md - Health check endpoints
 - spec/schema-api-metrics-endpoint.md - Prometheus metrics endpoint

--- a/spec/schema-api-dummies-crud.md
+++ b/spec/schema-api-dummies-crud.md
@@ -1055,10 +1055,12 @@ curl -X PATCH http://localhost:5000/v0/dummies/abc-123 \
 curl -X DELETE http://localhost:5000/v0/dummies/abc-123 \
   -b "access_token=<jwt>"
 
-# Response: 200 OK
-{
-  "message": "Dummy deleted successfully"
-}
+# Response: 204 No Content
+# Headers:
+#   X-Correlation-ID: <uuid>
+#   X-RateLimit-Limit: 100
+#   X-RateLimit-Remaining: 99
+#   X-RateLimit-Reset: 1700000000
 
 # 6. Verify deletion (soft delete)
 curl http://localhost:5000/v0/dummies \

--- a/spec/schema-api-health-endpoints.md
+++ b/spec/schema-api-health-endpoints.md
@@ -1,0 +1,574 @@
+---
+title: Health, Readiness and Version Endpoints Specification
+version: 1.0
+date_created: 2026-01-07
+last_updated: 2026-01-07
+owner: Backend Team
+tags: [infrastructure, health-check, monitoring, template]
+---
+
+# Introduction
+
+This specification defines three standard observability endpoints that MUST be present in all Waterfall microservices built from the wfp-flask-template. These endpoints enable Kubernetes health probes, monitoring, and version tracking without requiring authentication.
+
+## 1. Purpose & Scope
+
+**Purpose:**
+- Provide standardized health checking for Kubernetes liveness and readiness probes
+- Enable version tracking and debugging across deployed services
+- Support operational observability and incident response
+
+**Scope:**
+- Three endpoints: `/health`, `/ready`, `/version`
+- No authentication required (public endpoints)
+- No API version prefix (available at root path)
+- Included in base wfp-flask-template
+
+**Target Audience:**
+- DevOps/SRE teams configuring Kubernetes probes
+- Monitoring systems and dashboards
+- Developers debugging deployment issues
+
+**Assumptions:**
+- Services deployed on Kubernetes clusters
+- PostgreSQL database as primary data store
+- Optional Redis cache
+- VERSION file exists at repository root
+
+## 2. Definitions
+
+| Term | Definition |
+|------|------------|
+| Liveness Probe | Kubernetes mechanism to detect if a container needs restart |
+| Readiness Probe | Kubernetes mechanism to detect if a container can accept traffic |
+| Degraded State | Service is running but one or more non-critical dependencies are unavailable |
+| Health Check | Verification that service and dependencies are functioning |
+| SemVer | Semantic Versioning (MAJOR.MINOR.PATCH) |
+
+## 3. Requirements, Constraints & Guidelines
+
+### Functional Requirements (REQ-xxx)
+
+**REQ-001**: Service SHALL expose three health endpoints: `/health`, `/ready`, `/version`
+**REQ-002**: Endpoints SHALL be available without API version prefix (not `/v0/health`)
+**REQ-003**: Endpoints SHALL NOT require authentication or JWT token
+**REQ-004**: `/health` endpoint SHALL check database connectivity
+**REQ-005**: `/ready` endpoint SHALL check all critical dependencies (DB, external services)
+**REQ-006**: `/version` endpoint SHALL read version from `VERSION` file at repository root
+**REQ-007**: All endpoints SHALL return JSON responses
+**REQ-008**: Endpoints SHALL be registered before versioned API routes
+
+### Security Requirements (SEC-xxx)
+
+**SEC-001**: Endpoints SHALL NOT require JWT authentication (public access)
+**SEC-002**: Endpoints SHALL NOT expose sensitive information (credentials, internal IPs, stack traces)
+**SEC-003**: Endpoints SHALL rate limit to 100 requests per minute per IP
+**SEC-004**: Database health checks SHALL use read-only queries
+**SEC-005**: Version information SHALL NOT include developer names or internal paths
+
+### Performance Requirements (PERF-xxx)
+
+**PERF-001**: `/health` endpoint SHALL respond in < 200ms (99th percentile)
+**PERF-002**: `/ready` endpoint SHALL respond in < 500ms (99th percentile)
+**PERF-003**: `/version` endpoint SHALL respond in < 50ms (cached file read)
+**PERF-004**: Health checks SHALL use connection pooling (no new connections)
+**PERF-005**: Health checks SHALL timeout after 3 seconds
+
+### Constraints (CON-xxx)
+
+**CON-001**: Endpoints MUST NOT use versioned routes (`/v0/`, `/v1/`)
+**CON-002**: VERSION file MUST exist at repository root
+**CON-003**: Database check MUST be a lightweight query (e.g., `SELECT 1`)
+**CON-004**: Responses MUST be valid JSON (not plain text)
+
+### Guidelines (GUD-xxx)
+
+**GUD-001**: Use `HealthResource`, `ReadyResource`, `VersionResource` class names
+**GUD-002**: Place resources in `app/resources/health.py`
+**GUD-003**: Do not create database models for these endpoints
+**GUD-004**: Cache VERSION file content on application startup
+**GUD-005**: Log health check failures at WARNING level (not ERROR)
+
+## 4. Interfaces & Data Contracts
+
+### 4.1 GET /health - Liveness Probe
+
+**Endpoint:** `GET /health`
+
+**Description:** Checks if the application is alive and functioning. Used by Kubernetes liveness probes to detect if the container needs restart.
+
+#### Path Parameters
+None
+
+#### Query Parameters
+None
+
+#### Request Headers
+None required
+
+#### Request Body
+None
+
+#### Response Schemas
+
+**Success Response (200 OK - Healthy):**
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "ok",
+      "response_time_ms": 15
+    }
+  }
+}
+```
+
+**Success Response (200 OK - Degraded):**
+```json
+{
+  "status": "degraded",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "error",
+      "response_time_ms": 3000,
+      "error": "Connection timeout"
+    }
+  }
+}
+```
+
+**Error Response (500 Internal Server Error):**
+```json
+{
+  "status": "error",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "error": "Application initialization failed"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Service is alive (even if degraded) |
+| 500 | Internal Server Error | Application itself is broken (not dependencies) |
+
+#### Response Headers
+```
+Content-Type: application/json
+Cache-Control: no-cache, no-store, must-revalidate
+```
+
+---
+
+### 4.2 GET /ready - Readiness Probe
+
+**Endpoint:** `GET /ready`
+
+**Description:** Checks if the application is ready to accept traffic. Used by Kubernetes readiness probes to control load balancer routing.
+
+#### Path Parameters
+None
+
+#### Query Parameters
+None
+
+#### Request Headers
+None required
+
+#### Request Body
+None
+
+#### Response Schemas
+
+**Success Response (200 OK - Ready):**
+```json
+{
+  "status": "ready",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "ok",
+      "response_time_ms": 12
+    },
+    "redis": {
+      "status": "ok",
+      "response_time_ms": 5
+    },
+    "guardian_service": {
+      "status": "ok",
+      "response_time_ms": 45
+    }
+  }
+}
+```
+
+**Error Response (503 Service Unavailable - Not Ready):**
+```json
+{
+  "status": "not_ready",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "error",
+      "response_time_ms": 3000,
+      "error": "Connection refused"
+    },
+    "redis": {
+      "status": "ok",
+      "response_time_ms": 5
+    },
+    "guardian_service": {
+      "status": "ok",
+      "response_time_ms": 45
+    }
+  }
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Service is ready to accept traffic |
+| 503 | Service Unavailable | Critical dependency unavailable (DB, required external service) |
+
+#### Response Headers
+```
+Content-Type: application/json
+Cache-Control: no-cache, no-store, must-revalidate
+```
+
+---
+
+### 4.3 GET /version - Version Information
+
+**Endpoint:** `GET /version`
+
+**Description:** Returns version information about the deployed service for debugging and tracking.
+
+#### Path Parameters
+None
+
+#### Query Parameters
+None
+
+#### Request Headers
+None required
+
+#### Request Body
+None
+
+#### Response Schemas
+
+**Success Response (200 OK):**
+```json
+{
+  "version": "1.2.3",
+  "git_commit": "a1b2c3d",
+  "build_date": "2026-01-07T08:00:00Z",
+  "environment": "production"
+}
+```
+
+**Error Response (500 Internal Server Error):**
+```json
+{
+  "error": "VERSION file not found",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Version information retrieved |
+| 500 | Internal Server Error | VERSION file missing or unreadable |
+
+#### Response Headers
+```
+Content-Type: application/json
+Cache-Control: public, max-age=3600
+```
+
+## 5. Acceptance Criteria
+
+### AC-001: /health Endpoint
+- **Given** the application is running
+- **When** GET /health is called
+- **Then** response status is 200
+- **And** response contains "status" field with value "ok" or "degraded"
+- **And** response contains "timestamp" in ISO 8601 format
+- **And** response contains "checks.database" object
+
+### AC-002: /health with Database Down
+- **Given** the database is unavailable
+- **When** GET /health is called
+- **Then** response status is 200 (not 503)
+- **And** "status" field is "degraded"
+- **And** "checks.database.status" is "error"
+- **And** "checks.database.error" contains error description
+
+### AC-003: /ready Endpoint Success
+- **Given** all critical dependencies are available
+- **When** GET /ready is called
+- **Then** response status is 200
+- **And** "status" field is "ready"
+- **And** all checks show "status": "ok"
+
+### AC-004: /ready with Database Down
+- **Given** the database is unavailable
+- **When** GET /ready is called
+- **Then** response status is 503
+- **And** "status" field is "not_ready"
+- **And** "checks.database.status" is "error"
+
+### AC-005: /version Endpoint
+- **Given** VERSION file exists at repository root
+- **When** GET /version is called
+- **Then** response status is 200
+- **And** response contains "version" field from VERSION file
+- **And** response contains "git_commit" field
+- **And** response contains "build_date" field
+- **And** version follows SemVer format (e.g., "1.2.3")
+
+### AC-006: No Authentication Required
+- **Given** no JWT token provided
+- **When** any health endpoint is called
+- **Then** response is successful (not 401 Unauthorized)
+
+### AC-007: Rate Limiting
+- **Given** 101 requests from same IP in 1 minute
+- **When** request 101 is made
+- **Then** response status is 429 Too Many Requests
+
+### AC-008: Response Time
+- **Given** healthy system
+- **When** GET /health is called
+- **Then** response time is < 200ms (99th percentile)
+
+## 6. Test Automation Strategy
+
+**Test Levels:**
+- Unit tests: Health check logic, version file parsing
+- Integration tests: Database connectivity, external service checks
+- End-to-end tests: Kubernetes probe simulation
+
+**Frameworks:**
+- pytest for unit/integration tests
+- FlaskClient for endpoint testing
+- Docker Compose for integration test dependencies
+
+**Test Data Management:**
+- Mock VERSION file content
+- Mock database connection success/failure
+- Mock external service responses
+
+**CI/CD Integration:**
+- Run on every commit
+- Required for PR approval
+- Part of deployment pipeline
+
+**Coverage Requirements:**
+- Minimum 90% code coverage for health resources
+- All status codes tested
+- All error scenarios covered
+
+**Performance Testing:**
+- Load test with 1000 req/s
+- Verify response times under load
+- Ensure no memory leaks in health checks
+
+## 7. Rationale & Context
+
+**Why no authentication?**
+- Kubernetes probes cannot provide JWT tokens
+- Health endpoints don't expose sensitive data
+- Rate limiting provides sufficient protection
+
+**Why separate /health and /ready?**
+- Kubernetes best practice: separate liveness from readiness
+- Prevents unnecessary pod restarts due to transient dependency failures
+- Allows graceful degradation while maintaining service availability
+
+**Why read VERSION from file?**
+- Single source of truth for versioning
+- No need to update code for version bumps
+- CI/CD can inject version during build
+
+**Why 200 for degraded state?**
+- Avoid pod restarts when only dependencies are down
+- Service itself is functional
+- Allows monitoring to alert without immediate action
+
+**Why detailed checks object?**
+- Enables better debugging and incident response
+- Monitoring dashboards can show which dependency is failing
+- No need to check logs for basic health issues
+
+## 8. Dependencies & External Integrations
+
+### External Systems
+- **EXT-001**: PostgreSQL Database - Primary data store for all services
+- **EXT-002**: Redis Cache - Optional caching layer
+- **EXT-003**: Guardian Service - Authorization service (optional dependency)
+- **EXT-004**: Identity Service - Authentication service (optional dependency)
+
+### Infrastructure Dependencies
+- **INF-001**: Kubernetes - Container orchestration platform
+- **INF-002**: Load Balancer - Routes traffic based on readiness
+- **INF-003**: Monitoring - Prometheus/Grafana for metrics
+
+### Data Dependencies
+- **DAT-001**: VERSION file - Text file at repository root containing SemVer version
+
+### Technology Platform Dependencies
+- **PLT-001**: Flask web framework - For HTTP endpoint handling
+- **PLT-002**: SQLAlchemy - For database connection pooling and queries
+- **PLT-003**: Python 3.11+ - Runtime environment
+
+## 9. Examples & Edge Cases
+
+### Example 1: Normal Operation
+```bash
+# Health check - all systems operational
+curl http://localhost:5000/health
+
+# Response: 200 OK
+{
+  "status": "ok",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "ok",
+      "response_time_ms": 15
+    }
+  }
+}
+```
+
+### Example 2: Database Degraded
+```bash
+# Health check - database slow but responding
+curl http://localhost:5000/health
+
+# Response: 200 OK (degraded but not down)
+{
+  "status": "degraded",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "error",
+      "response_time_ms": 2800,
+      "error": "Query timeout exceeded 2000ms threshold"
+    }
+  }
+}
+```
+
+### Example 3: Readiness Check Failure
+```bash
+# Ready check - database unavailable
+curl http://localhost:5000/ready
+
+# Response: 503 Service Unavailable
+{
+  "status": "not_ready",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "error",
+      "response_time_ms": 3000,
+      "error": "Connection refused: [Errno 111] Connection refused"
+    },
+    "redis": {
+      "status": "ok",
+      "response_time_ms": 5
+    }
+  }
+}
+```
+
+### Example 4: Version Information
+```bash
+# Version check
+curl http://localhost:5000/version
+
+# Response: 200 OK
+{
+  "version": "1.2.3",
+  "git_commit": "a1b2c3d",
+  "build_date": "2026-01-07T08:00:00Z",
+  "environment": "production"
+}
+```
+
+### Edge Case 1: Missing VERSION File
+```bash
+curl http://localhost:5000/version
+
+# Response: 500 Internal Server Error
+{
+  "error": "VERSION file not found at repository root",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+### Edge Case 2: Database Connection Pool Exhausted
+```bash
+curl http://localhost:5000/ready
+
+# Response: 503 Service Unavailable
+{
+  "status": "not_ready",
+  "timestamp": "2026-01-07T10:30:00Z",
+  "checks": {
+    "database": {
+      "status": "error",
+      "response_time_ms": 3000,
+      "error": "Connection pool exhausted: QueuePool limit of size 10 overflow 10 reached"
+    }
+  }
+}
+```
+
+### Edge Case 3: Multiple Rapid Health Checks
+```bash
+# 100 requests in quick succession
+for i in {1..100}; do curl http://localhost:5000/health; done
+
+# All succeed: 200 OK
+# Request 101:
+curl http://localhost:5000/health
+
+# Response: 429 Too Many Requests
+{
+  "message": "Rate limit exceeded: 100 per minute",
+  "retry_after": 45
+}
+```
+
+## 10. Validation Criteria
+
+- **VAL-001**: All three endpoints return valid JSON (validated with jsonschema)
+- **VAL-002**: /health returns 200 in all scenarios except application crash
+- **VAL-003**: /ready returns 503 when any critical dependency is down
+- **VAL-004**: /version matches content of VERSION file
+- **VAL-005**: Response times meet performance requirements (PERF-001, PERF-002, PERF-003)
+- **VAL-006**: No authentication errors (401) when called without token
+- **VAL-007**: Rate limiting triggers at 101st request within 1 minute
+- **VAL-008**: Database health check uses `SELECT 1` query (lightweight)
+- **VAL-009**: No sensitive information in error messages
+- **VAL-010**: Timestamps use ISO 8601 format with UTC timezone
+
+## 11. Related Specifications / Further Reading
+
+- [Kubernetes Liveness and Readiness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+- [Health Check Response Format for HTTP APIs (RFC Draft)](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check)
+- [Semantic Versioning 2.0.0](https://semver.org/)
+- [wfp-flask-template Architecture Documentation](../docs/architecture.md)
+- [Guardian Service Integration Guide](../docs/guardian-integration.md)

--- a/spec/schema-api-metrics-endpoint.md
+++ b/spec/schema-api-metrics-endpoint.md
@@ -1,0 +1,509 @@
+---
+title: Prometheus Metrics Endpoint Specification
+version: 1.0
+date_created: 2026-01-07
+last_updated: 2026-01-07
+owner: Backend Team
+tags: [infrastructure, monitoring, prometheus, observability, template]
+---
+
+# Introduction
+
+This specification defines the `/metrics` endpoint that exposes Prometheus-compatible metrics for all Waterfall microservices built from the wfp-flask-template. This endpoint enables comprehensive monitoring and observability through Prometheus scraping.
+
+## 1. Purpose & Scope
+
+**Purpose:**
+- Expose application, HTTP, and system metrics in Prometheus format
+- Enable monitoring, alerting, and performance analysis
+- Provide standardized metrics across all Waterfall services
+
+**Scope:**
+- Single endpoint: `/metrics`
+- API key authentication required
+- Prometheus text exposition format
+- Included in base wfp-flask-template
+- Uses `prometheus-flask-exporter` library
+
+**Target Audience:**
+- SRE/DevOps teams configuring Prometheus scraping
+- Monitoring and alerting systems
+- Performance analysis and capacity planning
+
+**Assumptions:**
+- Prometheus server deployed and configured
+- API key distributed to Prometheus via configuration
+- Services deployed on Kubernetes with service discovery
+
+## 2. Definitions
+
+| Term | Definition |
+|------|------------|
+| Prometheus | Open-source monitoring and alerting toolkit |
+| Scraping | Prometheus pulling metrics from service endpoints |
+| Metric | Time-series data point with labels (e.g., http_requests_total) |
+| Label | Key-value pair attached to metric (e.g., method="GET") |
+| Gauge | Metric that can go up or down (e.g., memory usage) |
+| Counter | Metric that only increases (e.g., request count) |
+| Histogram | Metric tracking distribution (e.g., response time buckets) |
+| Exposition Format | Prometheus text-based format for metrics |
+
+## 3. Requirements, Constraints & Guidelines
+
+### Functional Requirements (REQ-xxx)
+
+**REQ-001**: Service SHALL expose `/metrics` endpoint in Prometheus exposition format
+**REQ-002**: Endpoint SHALL return `Content-Type: text/plain; version=0.0.4; charset=utf-8`
+**REQ-003**: Endpoint SHALL expose HTTP request metrics (count, duration, status codes)
+**REQ-004**: Endpoint SHALL expose system metrics (CPU, memory, threads)
+**REQ-005**: Endpoint SHALL expose database connection pool metrics
+**REQ-006**: Endpoint SHALL use `prometheus-flask-exporter` library
+**REQ-007**: Endpoint SHALL be available without API version prefix (not `/v0/metrics`)
+**REQ-008**: Metrics SHALL include labels: `method`, `endpoint`, `status_code`, `service_name`
+**REQ-009**: HTTP duration metrics SHALL use histogram with standard buckets
+
+### Security Requirements (SEC-xxx)
+
+**SEC-001**: Endpoint SHALL require API key authentication via `Authorization: Bearer <key>` header
+**SEC-002**: API key SHALL be configured via `METRICS_API_KEY` environment variable
+**SEC-003**: Missing or invalid API key SHALL return 401 Unauthorized
+**SEC-004**: Endpoint SHALL NOT expose sensitive data (credentials, tokens, PII)
+**SEC-005**: Endpoint SHALL rate limit to 10 requests per minute per IP
+**SEC-006**: API key SHALL be minimum 32 characters alphanumeric
+**SEC-007**: Endpoint SHALL log authentication failures at WARNING level
+
+### Performance Requirements (PERF-xxx)
+
+**PERF-001**: Endpoint SHALL respond in < 100ms for typical metric payload
+**PERF-002**: Metric collection SHALL NOT block request processing
+**PERF-003**: Metrics SHALL be cached for 5 seconds (avoid computation on every scrape)
+**PERF-004**: Endpoint SHALL handle concurrent Prometheus scrapers gracefully
+**PERF-005**: Memory overhead for metrics SHALL be < 50MB
+
+### Constraints (CON-xxx)
+
+**CON-001**: Endpoint MUST use Prometheus text exposition format (not JSON)
+**CON-002**: Endpoint MUST NOT use versioned routes (`/v0/`, `/v1/`)
+**CON-003**: Metric names MUST follow Prometheus naming conventions (lowercase, underscores)
+**CON-004**: METRICS_API_KEY environment variable MUST be set (no default)
+**CON-005**: Histogram buckets MUST use standard Prometheus defaults
+
+### Guidelines (GUD-xxx)
+
+**GUD-001**: Use `prometheus-flask-exporter` for automatic Flask integration
+**GUD-002**: Configure metrics in `app/__init__.py` on application startup
+**GUD-003**: Do not create custom resource class (prometheus-flask-exporter handles it)
+**GUD-004**: Add service name label from environment variable `SERVICE_NAME`
+**GUD-005**: Exclude health endpoints from HTTP metrics (reduce noise)
+**GUD-006**: Use standard Prometheus metric naming (suffixes: _total, _seconds, _bytes)
+
+## 4. Interfaces & Data Contracts
+
+### GET /metrics - Prometheus Metrics Endpoint
+
+**Endpoint:** `GET /metrics`
+
+**Description:** Exposes application metrics in Prometheus text exposition format for scraping by Prometheus server.
+
+#### Path Parameters
+None
+
+#### Query Parameters
+None
+
+#### Request Headers
+
+| Header | Required | Description | Example |
+|--------|----------|-------------|---------|
+| Authorization | Yes | Bearer token with API key | `Bearer abc123def456...` |
+
+#### Request Body
+None
+
+#### Response Format
+
+**Success Response (200 OK):**
+
+```text
+# HELP python_info Python platform information
+# TYPE python_info gauge
+python_info{implementation="CPython",major="3",minor="11",patchlevel="7",version="3.11.7"} 1.0
+
+# HELP flask_http_request_duration_seconds Flask HTTP request duration in seconds
+# TYPE flask_http_request_duration_seconds histogram
+flask_http_request_duration_seconds_bucket{le="0.005",method="GET",path="/v0/projects",status="200"} 145.0
+flask_http_request_duration_seconds_bucket{le="0.01",method="GET",path="/v0/projects",status="200"} 234.0
+flask_http_request_duration_seconds_bucket{le="0.025",method="GET",path="/v0/projects",status="200"} 289.0
+flask_http_request_duration_seconds_bucket{le="0.05",method="GET",path="/v0/projects",status="200"} 310.0
+flask_http_request_duration_seconds_bucket{le="0.1",method="GET",path="/v0/projects",status="200"} 325.0
+flask_http_request_duration_seconds_bucket{le="0.25",method="GET",path="/v0/projects",status="200"} 340.0
+flask_http_request_duration_seconds_bucket{le="0.5",method="GET",path="/v0/projects",status="200"} 345.0
+flask_http_request_duration_seconds_bucket{le="1.0",method="GET",path="/v0/projects",status="200"} 348.0
+flask_http_request_duration_seconds_bucket{le="2.5",method="GET",path="/v0/projects",status="200"} 350.0
+flask_http_request_duration_seconds_bucket{le="5.0",method="GET",path="/v0/projects",status="200"} 350.0
+flask_http_request_duration_seconds_bucket{le="10.0",method="GET",path="/v0/projects",status="200"} 350.0
+flask_http_request_duration_seconds_bucket{le="+Inf",method="GET",path="/v0/projects",status="200"} 350.0
+flask_http_request_duration_seconds_count{method="GET",path="/v0/projects",status="200"} 350.0
+flask_http_request_duration_seconds_sum{method="GET",path="/v0/projects",status="200"} 8.75
+
+# HELP flask_http_request_total Total number of HTTP requests
+# TYPE flask_http_request_total counter
+flask_http_request_total{method="GET",status="200"} 1234.0
+flask_http_request_total{method="POST",status="201"} 567.0
+flask_http_request_total{method="GET",status="404"} 89.0
+flask_http_request_total{method="POST",status="422"} 23.0
+
+# HELP flask_http_request_exceptions_total Total number of HTTP requests which resulted in an exception
+# TYPE flask_http_request_exceptions_total counter
+flask_http_request_exceptions_total 5.0
+
+# HELP process_virtual_memory_bytes Virtual memory size in bytes
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 234567890.0
+
+# HELP process_resident_memory_bytes Resident memory size in bytes
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 123456789.0
+
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 123.45
+
+# HELP sqlalchemy_pool_size Current size of the connection pool
+# TYPE sqlalchemy_pool_size gauge
+sqlalchemy_pool_size 5.0
+
+# HELP sqlalchemy_pool_checked_in_connections Number of connections currently checked in to the pool
+# TYPE sqlalchemy_pool_checked_in_connections gauge
+sqlalchemy_pool_checked_in_connections 4.0
+
+# HELP sqlalchemy_pool_checked_out_connections Number of connections currently checked out of the pool
+# TYPE sqlalchemy_pool_checked_out_connections gauge
+sqlalchemy_pool_checked_out_connections 1.0
+
+# HELP sqlalchemy_pool_overflow Number of connections in overflow
+# TYPE sqlalchemy_pool_overflow gauge
+sqlalchemy_pool_overflow 0.0
+```
+
+**Error Response (401 Unauthorized - Missing API Key):**
+
+```json
+{
+  "message": "Missing Authorization header",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+**Error Response (401 Unauthorized - Invalid API Key):**
+
+```json
+{
+  "message": "Invalid API key",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+**Error Response (429 Too Many Requests):**
+
+```json
+{
+  "message": "Rate limit exceeded: 10 per minute",
+  "retry_after": 45
+}
+```
+
+#### Status Codes
+
+| Code | Description | When to Use |
+|------|-------------|-------------|
+| 200 | OK | Valid API key, metrics returned |
+| 401 | Unauthorized | Missing or invalid API key |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Metrics collection failed |
+
+#### Response Headers
+
+**Success (200):**
+```
+Content-Type: text/plain; version=0.0.4; charset=utf-8
+Cache-Control: no-cache, no-store, must-revalidate
+```
+
+**Error (401, 429):**
+```
+Content-Type: application/json
+Cache-Control: no-cache, no-store, must-revalidate
+```
+
+## 5. Acceptance Criteria
+
+### AC-001: Metrics Endpoint with Valid API Key
+- **Given** METRICS_API_KEY environment variable is set
+- **And** Authorization header contains valid Bearer token
+- **When** GET /metrics is called
+- **Then** response status is 200
+- **And** response Content-Type is `text/plain; version=0.0.4; charset=utf-8`
+- **And** response body contains Prometheus metrics in text format
+
+### AC-002: Missing API Key
+- **Given** METRICS_API_KEY is configured
+- **And** no Authorization header is provided
+- **When** GET /metrics is called
+- **Then** response status is 401
+- **And** response is JSON with "Missing Authorization header" message
+
+### AC-003: Invalid API Key
+- **Given** METRICS_API_KEY is "validkey123"
+- **And** Authorization header is "Bearer wrongkey456"
+- **When** GET /metrics is called
+- **Then** response status is 401
+- **And** response is JSON with "Invalid API key" message
+
+### AC-004: HTTP Metrics Exposed
+- **Given** application has received HTTP requests
+- **When** GET /metrics is called with valid key
+- **Then** response contains `flask_http_request_total` counter
+- **And** response contains `flask_http_request_duration_seconds` histogram
+- **And** metrics include labels: method, path, status
+
+### AC-005: System Metrics Exposed
+- **Given** application is running
+- **When** GET /metrics is called with valid key
+- **Then** response contains `process_virtual_memory_bytes` gauge
+- **And** response contains `process_resident_memory_bytes` gauge
+- **And** response contains `process_cpu_seconds_total` counter
+
+### AC-006: Database Pool Metrics Exposed
+- **Given** database connection pool is active
+- **When** GET /metrics is called with valid key
+- **Then** response contains `sqlalchemy_pool_size` gauge
+- **And** response contains `sqlalchemy_pool_checked_out_connections` gauge
+
+### AC-007: Health Endpoints Excluded
+- **Given** /health endpoint has been called 100 times
+- **When** GET /metrics is called
+- **Then** /health requests are NOT included in flask_http_request_total
+- **And** /ready and /version are also excluded
+
+### AC-008: Rate Limiting
+- **Given** 11 requests from same IP in 1 minute
+- **When** request 11 is made
+- **Then** response status is 429
+
+### AC-009: Response Time
+- **Given** typical metric payload (100 metric series)
+- **When** GET /metrics is called
+- **Then** response time is < 100ms
+
+### AC-010: Metric Naming Conventions
+- **Given** metrics are exposed
+- **Then** all metric names use lowercase with underscores
+- **And** counter metrics end with `_total` suffix
+- **And** duration metrics end with `_seconds` suffix
+- **And** size metrics end with `_bytes` suffix
+
+## 6. Test Automation Strategy
+
+**Test Levels:**
+- Unit tests: API key validation logic
+- Integration tests: Prometheus metric collection and formatting
+- End-to-end tests: Prometheus scraping simulation
+
+**Frameworks:**
+- pytest for unit/integration tests
+- FlaskClient for endpoint testing
+- prometheus-client parser for validating metric format
+
+**Test Data Management:**
+- Mock METRICS_API_KEY environment variable
+- Generate test HTTP traffic for metric collection
+- Mock database connection pool
+
+**CI/CD Integration:**
+- Run on every commit
+- Validate Prometheus format with parser
+- Check for metric regression
+
+**Coverage Requirements:**
+- Minimum 85% code coverage for authentication logic
+- All status codes tested
+- Metric format validation
+
+**Performance Testing:**
+- Benchmark metric collection overhead
+- Verify response time under load
+- Test with 1000+ metric series
+
+## 7. Rationale & Context
+
+**Why API key authentication?**
+- Metrics can reveal system architecture and traffic patterns
+- Prevents unauthorized metric scraping
+- Simpler than mTLS for initial implementation
+- Sufficient security for internal Prometheus scraper
+
+**Why text/plain format (not JSON)?**
+- Prometheus standard exposition format
+- More efficient for Prometheus parser
+- Industry standard for metrics
+- Better compression for large metric sets
+
+**Why prometheus-flask-exporter?**
+- Automatic Flask integration (decorators work automatically)
+- Minimal configuration required
+- Battle-tested in production
+- Standard histogram buckets pre-configured
+
+**Why exclude health endpoints?**
+- Health endpoints called very frequently by K8s probes
+- Would dominate metrics and create noise
+- Not useful for application monitoring
+- Can overwhelm Prometheus with cardinality
+
+**Why 5-second cache?**
+- Balance freshness vs performance
+- Prometheus default scrape interval is 15s
+- Reduces CPU overhead on each scrape
+- Still provides near real-time metrics
+
+**Why standard histogram buckets?**
+- Compatible with Prometheus conventions
+- Covers typical API response times (5ms to 10s)
+- Enables accurate percentile calculations
+- Industry best practice
+
+## 8. Dependencies & External Integrations
+
+### External Systems
+- **EXT-001**: Prometheus Server - Metrics collection and storage system
+
+### Infrastructure Dependencies
+- **INF-001**: Kubernetes Service Discovery - For Prometheus to discover service endpoints
+- **INF-002**: Network Policies - Allow Prometheus scraper access to /metrics
+
+### Technology Platform Dependencies
+- **PLT-001**: prometheus-flask-exporter - Python library for Flask metrics
+- **PLT-002**: prometheus-client - Core Prometheus client library
+- **PLT-003**: Flask web framework - For HTTP endpoint handling
+- **PLT-004**: Python 3.11+ - Runtime environment
+
+### Data Dependencies
+- **DAT-001**: METRICS_API_KEY - Environment variable containing API key
+- **DAT-002**: SERVICE_NAME - Environment variable for service identification
+
+## 9. Examples & Edge Cases
+
+### Example 1: Normal Scraping
+```bash
+# Prometheus scrapes metrics
+curl -H "Authorization: Bearer your-secret-api-key-here" \
+     http://localhost:5000/metrics
+
+# Response: 200 OK (text/plain)
+# HELP flask_http_request_total Total number of HTTP requests
+# TYPE flask_http_request_total counter
+flask_http_request_total{method="GET",status="200"} 1234.0
+flask_http_request_total{method="POST",status="201"} 567.0
+...
+```
+
+### Example 2: Missing Authorization Header
+```bash
+curl http://localhost:5000/metrics
+
+# Response: 401 Unauthorized (application/json)
+{
+  "message": "Missing Authorization header",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+### Example 3: Invalid API Key Format
+```bash
+curl -H "Authorization: InvalidFormat" \
+     http://localhost:5000/metrics
+
+# Response: 401 Unauthorized
+{
+  "message": "Invalid Authorization format. Expected: Bearer <key>",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+### Example 4: Wrong API Key
+```bash
+curl -H "Authorization: Bearer wrong-key-123" \
+     http://localhost:5000/metrics
+
+# Response: 401 Unauthorized
+{
+  "message": "Invalid API key",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+### Edge Case 1: METRICS_API_KEY Not Set
+```bash
+# Application startup fails
+RuntimeError: METRICS_API_KEY environment variable not set
+Application will not start without metrics API key configured
+```
+
+### Edge Case 2: Empty Metrics (New Service)
+```bash
+curl -H "Authorization: Bearer valid-key" \
+     http://localhost:5000/metrics
+
+# Response: 200 OK
+# Only default Python/process metrics, no HTTP metrics yet
+# HELP python_info Python platform information
+# TYPE python_info gauge
+python_info{implementation="CPython",major="3",minor="11"} 1.0
+```
+
+### Edge Case 3: High Cardinality Warning
+```bash
+# If endpoint includes dynamic IDs: /v0/projects/{uuid}
+# Bad: flask_http_request_total{path="/v0/projects/uuid-1"} 1.0
+#      flask_http_request_total{path="/v0/projects/uuid-2"} 1.0
+#      (thousands of unique paths = cardinality explosion)
+
+# Good: Normalize path before labeling
+flask_http_request_total{path="/v0/projects/<uuid>"} 1234.0
+```
+
+### Edge Case 4: Metric Collection Failure
+```bash
+curl -H "Authorization: Bearer valid-key" \
+     http://localhost:5000/metrics
+
+# Response: 500 Internal Server Error
+{
+  "message": "Failed to collect metrics",
+  "error": "Database connection pool not initialized",
+  "timestamp": "2026-01-07T10:30:00Z"
+}
+```
+
+## 10. Validation Criteria
+
+- **VAL-001**: Response format validates against Prometheus text exposition format parser
+- **VAL-002**: All metric names follow naming conventions (lowercase, underscores, suffixes)
+- **VAL-003**: HTTP histogram includes all standard buckets (0.005 to 10.0 seconds)
+- **VAL-004**: API key authentication rejects invalid/missing keys with 401
+- **VAL-005**: Rate limiting triggers at 11th request within 1 minute
+- **VAL-006**: Response time < 100ms for typical payload (< 500 metric series)
+- **VAL-007**: Health endpoints (/health, /ready, /version) excluded from HTTP metrics
+- **VAL-008**: Metric labels include: method, endpoint, status_code
+- **VAL-009**: No sensitive data in metric labels or values
+- **VAL-010**: Application fails to start if METRICS_API_KEY not set
+
+## 11. Related Specifications / Further Reading
+
+- [Prometheus Exposition Formats](https://prometheus.io/docs/instrumenting/exposition_formats/)
+- [Prometheus Best Practices - Metric and Label Naming](https://prometheus.io/docs/practices/naming/)
+- [prometheus-flask-exporter Documentation](https://github.com/rycus86/prometheus_flask_exporter)
+- [Prometheus Python Client](https://github.com/prometheus/client_python)
+- [Avoiding High Cardinality in Prometheus](https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels)
+- spec/schema-api-health-endpoints.md - Related health check endpoints


### PR DESCRIPTION
## Description
Add comprehensive OpenAPI 3.0.3 specifications and corresponding markdown documentation for all API endpoints (dummies CRUD, health checks, metrics). Includes Redocly linting configuration and license files.

## Type of Change
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change

## Related Issues
Refs: #11 (if exists - API documentation)

## Changes Made

### OpenAPI Specifications
- **dummies-api.yaml**: Complete CRUD API spec with JWT + Guardian auth
  - List endpoint with pagination and sorting
  - Create, Read, Update, Delete operations
  - DELETE returns 204 No Content (REST standard)
  - 410 Gone for already soft-deleted resources
  - is_active constrained to enum [false] to prevent reactivation
- **health-endpoints.yaml**: Health, readiness, and version endpoints (public)
- **metrics-endpoint.yaml**: Prometheus metrics endpoint with API key auth

### Markdown Specifications
- **schema-api-dummies-crud.md**: Detailed requirements (REQ, SEC, PERF, CON, GUD)
  - Functional, security, performance requirements
  - Acceptance criteria per endpoint
  - Guardian integration details
- **schema-api-health-endpoints.md**: Infrastructure endpoints spec
- **schema-api-metrics-endpoint.md**: Observability endpoint spec

### Configuration & Licensing
- **.redocly.yaml**: Redocly CLI config (suppress localhost warnings)
- **LICENSE**: MIT license (open source)
- **LICENSE.md**: MIT license markdown format
- **COMMERCIAL-LICENSE.txt**: Commercial license option

### Key Improvements
- All correlation_id examples use valid UUID v4 format
- x-guardian-operation annotations on all protected endpoints
- Standardized response headers via components.headers
- License information included in all OpenAPI specs
- Zero Redocly warnings achieved

## Testing
- [x] Manual testing completed
- [x] OpenAPI specs validated with Redocly CLI
- [x] Zero warnings achieved

### Validation Results
```bash
npx @redocly/cli lint --config .redocly.yaml openapi/**/*.yaml
# ✅ All specs valid, 0 warnings
```

## Checklist
- [x] Documentation follows project standards
- [x] Self-review completed
- [x] OpenAPI specs validated (zero warnings)
- [x] Markdown specs include comprehensive requirements
- [x] Examples use valid data formats (UUIDs, timestamps)
- [x] Guardian operations documented
- [x] License information included
- [x] No merge conflicts
- [x] Branch is up to date with develop
- [x] Commits follow conventional commit format

## OpenAPI Details

### Security Schemes
- **CookieAuth**: JWT via access_token cookie (dummies endpoints)
- **ApiKeyAuth**: Bearer token via Authorization header (metrics endpoint)
- **Public**: No auth required (health endpoints)

### Guardian Operations
All dummies endpoints annotated with `x-guardian-operation`:
- LIST: `GET /v0/dummies`
- CREATE: `POST /v0/dummies`
- READ: `GET /v0/dummies/{id}`
- UPDATE: `PATCH /v0/dummies/{id}`
- DELETE: `DELETE /v0/dummies/{id}`

### Standards Compliance
- OpenAPI 3.0.3 specification
- REST best practices (204 for DELETE, 410 for already deleted)
- Semantic versioning in API paths (/v0/)
- Prometheus text exposition format for metrics

## Documentation Coverage

### Requirements Documented
- **Functional**: 17 requirements (REQ-001 to REQ-017)
- **Security**: 12 requirements (SEC-001 to SEC-012)
- **Performance**: 7 requirements (PERF-001 to PERF-007)
- **Constraints**: 7 constraints (CON-001 to CON-007)
- **Guidelines**: 10 guidelines (GUD-001 to GUD-010)

### Acceptance Criteria
- 15+ acceptance criteria for dummies CRUD operations
- Given-When-Then format for testability
- Edge cases documented (duplicates, race conditions, etc.)

## Reviewer Notes
Please verify:
- OpenAPI specs structure and completeness
- Alignment between YAML and markdown specs
- Requirements coverage and clarity
- License information appropriateness
- Redocly validation passes in CI (PR #10)