### PR TITLE
fix(docker): upgrade Debian packages to patch security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install build dependencies and upgrade system packages for security patches
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     libpq-dev \
@@ -112,8 +114,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Install only runtime system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install runtime dependencies and upgrade system packages for security patches
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
     curl \
     libpq5 \
     postgresql-client \


### PR DESCRIPTION
## Description
Patches critical and high-severity security vulnerabilities detected by Trivy in Docker base image packages.

## Type of Change
- [ ] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition or update
- [x] 🔧 Configuration change

## Security Vulnerabilities Fixed

### CVE-2025-4802 (HIGH) - glibc setuid binary vulnerability
- **Affected packages**: libc-bin, libc6
- **Current version**: 2.36-9+deb12u10
- **Fixed version**: 2.36-9+deb12u11
- **Impact**: Potential privilege escalation in setuid binaries

### CVE-2025-6965 (CRITICAL) - SQLite integer truncation
- **Affected package**: libsqlite3-0
- **Current version**: 3.40.1-2+deb12u1
- **Fixed version**: 3.40.1-2+deb12u2
- **Impact**: Integer overflow leading to potential memory corruption

## Changes Made
- Added `apt-get upgrade -y` in builder stage after `apt-get install`
- Added `apt-get upgrade -y` in production stage after `apt-get install`
- Both stages now upgrade all Debian packages to latest security patches
- Maintains `--no-install-recommends` flag to keep image size minimal

## Testing
- [x] Docker build succeeds for all stages (builder, test, production)
- [x] Trivy security scan should now pass
- [x] No functional changes to application code

## Checklist
- [x] Security vulnerabilities identified by Trivy
- [x] Minimal changes to Dockerfile (only apt-get upgrade added)
- [x] No breaking changes to application
- [x] Image size increase is acceptable for security patches
- [x] All Docker stages updated consistently

## Why Hotfix Branch?
This fix was created after PR #14 was already merged. Since this addresses **CRITICAL** security vulnerabilities, it's being delivered as a separate hotfix to ensure develop has the security patches applied immediately.